### PR TITLE
minor fix for S2F_SYNC using parameter as register width

### DIFF
--- a/hardware/include/iob_lib.vh
+++ b/hardware/include/iob_lib.vh
@@ -86,8 +86,8 @@
    reg [W-1:0] IN``_sync [1:0]; \
    always @(posedge CLK, posedge RST) \
    if(RST) begin \
-      IN``_sync[0] <= W'b0; \
-      IN``_sync[1] <= W'b0; \
+      IN``_sync[0] <= {W{1'b0}}; \
+      IN``_sync[1] <= {W{1'b0}}; \
    end else begin \
       IN``_sync[0] <= IN; \
       IN``_sync[1] <= IN``_sync[0]; \

--- a/hardware/include/iob_lib.vh
+++ b/hardware/include/iob_lib.vh
@@ -86,8 +86,8 @@
    reg [W-1:0] IN``_sync [1:0]; \
    always @(posedge CLK, posedge RST) \
    if(RST) begin \
-      IN``_sync[0] <= {W{1'b0}}; \
-      IN``_sync[1] <= {W{1'b0}}; \
+      IN``_sync[0] <= !1; \
+      IN``_sync[1] <= !1; \
    end else begin \
       IN``_sync[0] <= IN; \
       IN``_sync[1] <= IN``_sync[0]; \


### PR DESCRIPTION
- Fixed S2F_SYNC macro syntax to work for register widths that use a parameter