### PR TITLE
Improved RESET_SYNC macro

### DIFF
--- a/hardware/include/iob_lib.vh
+++ b/hardware/include/iob_lib.vh
@@ -77,10 +77,10 @@
 
 // SYNCRONIZERS
 `define RESET_SYNC(CLK, RST_IN, RST_OUT) \
-   reg [1:0] RST_IN``_sync; \
+   reg [1:0] RST_IN``_``RST_OUT``_sync; \
    always @(posedge CLK, posedge RST_IN) \
-   if(RST_IN)  RST_IN``_sync <= 2'b11; else RST_IN``_sync <= {RST_IN``_sync[0], 1'b0}; \
-   `COMB RST_OUT = RST_IN``_sync[1];
+   if(RST_IN)  RST_IN``_``RST_OUT``_sync <= 2'b11; else RST_IN``_``RST_OUT``_sync <= {RST_IN``_``RST_OUT``_sync[0], 1'b0}; \
+   `COMB RST_OUT = RST_IN``_``RST_OUT``_sync[1];
 
 `define S2F_SYNC(CLK, RST, W, IN, OUT) \
    reg [W-1:0] IN``_sync [1:0]; \


### PR DESCRIPTION
RESET_SYNC() macro uses source and destination signals to generate the auxiliar register.
This facilitates cases when the signal in the source clock domain is synchronized to multiple destination clock domains.

Example: to sync the `rst` signal from the `sysclk` domain to `clk_in` and `clk_out` domains we would do:
```
`RESET_SYNC(clk_in, rst, rst_in)
`RESET_SYNC(clk_out, rst, rst_out)
```
But previously this would lead to a synthesis error, since each macro would create an auxiliar register array:
`reg [1:0] rst_sync;`
with this change now the auxiliar register is unique:
`reg [1:0] rst_rst_in_sync;` and 
`reg [1:0] rst_rst_out_sync` respectively

This change has been tested in vivado
