### PR TITLE
fix(python): Update mkregs.py to python3

### DIFF
--- a/software/mkregs.py
+++ b/software/mkregs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.7
+#!/usr/bin/python3
 #
 #    Build Latex tables of verilog module interface signals and registers
 #


### PR DESCRIPTION
- Only needed to execute as python3 all syntax is compatible