### PR TITLE
Added iob_lib.vh to VHDR in hardware.mk so that it appears in VHDR 

### DIFF
--- a/hardware/hardware.mk
+++ b/hardware/hardware.mk
@@ -3,5 +3,6 @@ MODULES+=$(shell make -C $(LIB_DIR) corename | grep -v make)
 
 #header
 INCLUDE+=$(incdir)$(LIB_DIR)/hardware/include
+VHDR+=$(LIB_DIR)/hardware/include/iob_lib.vh
 #verilog sources
 $(foreach p, $(LIBVSRC), $(eval VSRC+=$p))


### PR DESCRIPTION
Hi,
iob_lib.vh has been added to VHDR. It was added yesterday after discussion with Joao and after its addition we will be able to see iob_lib.vh in VHDR in skywater Makefile
Kindly have a look at it 
regards,
