### PR TITLE
Added testbench and small fixes to iob2axi

### DIFF
--- a/hardware/iob2axi/Makefile
+++ b/hardware/iob2axi/Makefile
@@ -1,0 +1,28 @@
+
+#icarus verilog simulator
+VLOG:=iverilog -W all -g2005-sv
+
+VSRC:=iob2axi.v iob2axi_wr.v iob2axi_rd.v iob2axi_tb.v
+VSRC+=../../submodules/AXI/rtl/axi_ram.v
+
+INCLUDE:=../include
+
+VCD_FILE:=uut.vcd
+
+a.out: $(VSRC)
+	$(VLOG) -I $(INCLUDE) -D VCD $(VSRC)
+
+$(VCD_FILE): a.out
+	./a.out
+
+sim: $(VCD_FILE)
+
+sim-waves: $(VCD_FILE)
+	gtkwave -a waves.gtkw $(VCD_FILE) &
+
+clean:
+	@rm -f a.out *~ $(VCD_FILE)
+
+.PRECIOUS: $(VCD_FILE)
+	
+.PHONY: sim sim-waves clean

--- a/hardware/iob2axi/iob2axi_rd.v
+++ b/hardware/iob2axi/iob2axi_rd.v
@@ -54,6 +54,8 @@ module iob2axi_rd
    reg                     m_axi_rready_int;
 
    // Control register signals
+   reg [`AXI_LEN_W-1:0]    length_reg;
+
    reg                     s_ready_int;
 
    // Read address
@@ -85,6 +87,15 @@ module iob2axi_rd
          ready <= ready_nxt;
          s_ready <= s_ready_int;
          s_rdata <= m_axi_rdata;
+      end
+   end
+
+   // Control registers
+   always @(posedge clk, posedge rst) begin
+      if (rst) begin
+         length_reg <= `AXI_LEN_W'd0;
+      end else if (state == ADDR_HS) begin
+         length_reg <= length;
       end
    end
 
@@ -151,7 +162,7 @@ module iob2axi_rd
            m_axi_rready_int = s_valid;
 
            if (m_axi_rvalid) begin
-              if (s_valid & counter == length) begin
+              if (s_valid & counter == length_reg) begin
                  error_nxt = ~m_axi_rlast;
 
                  state_nxt = ADDR_HS;

--- a/hardware/iob2axi/iob2axi_rd.v
+++ b/hardware/iob2axi/iob2axi_rd.v
@@ -54,16 +54,13 @@ module iob2axi_rd
    reg                     m_axi_rready_int;
 
    // Control register signals
-   reg [ADDR_W-1:0]        addr_reg;
-   reg [`AXI_LEN_W-1:0]    length_reg;
-
    reg                     s_ready_int;
 
    // Read address
    assign m_axi_arid = `AXI_ID_W'b0;
    assign m_axi_arvalid = m_axi_arvalid_int;
-   assign m_axi_araddr = addr_reg;
-   assign m_axi_arlen = length_reg;
+   assign m_axi_araddr = s_addr;
+   assign m_axi_arlen = length;
    assign m_axi_arsize = axi_arsize;
    assign m_axi_arburst = `AXI_BURST_W'd1;
    assign m_axi_arlock = `AXI_LOCK_W'b0;
@@ -88,17 +85,6 @@ module iob2axi_rd
          ready <= ready_nxt;
          s_ready <= s_ready_int;
          s_rdata <= m_axi_rdata;
-      end
-   end
-
-   // Control registers
-   always @(posedge clk, posedge rst) begin
-      if (rst) begin
-         addr_reg <= {ADDR_W{1'b0}};
-         length_reg <= `AXI_LEN_W'd0;
-      end else if (state == ADDR_HS) begin
-         addr_reg <= s_addr;
-         length_reg <= length;
       end
    end
 
@@ -165,7 +151,7 @@ module iob2axi_rd
            m_axi_rready_int = s_valid;
 
            if (m_axi_rvalid) begin
-              if (s_valid & counter == length_reg) begin
+              if (s_valid & counter == length) begin
                  error_nxt = ~m_axi_rlast;
 
                  state_nxt = ADDR_HS;

--- a/hardware/iob2axi/iob2axi_rd.v
+++ b/hardware/iob2axi/iob2axi_rd.v
@@ -81,7 +81,7 @@ module iob2axi_rd
          error <= 1'b0;
          ready <= 1'b1;
          s_ready <= 1'b0;
-         s_rdata <= `DATA_W'd0;
+         s_rdata <= {DATA_W{1'd0}};
       end else begin
          counter <= counter_nxt;
          error <= error_nxt;

--- a/hardware/iob2axi/iob2axi_tb.v
+++ b/hardware/iob2axi/iob2axi_tb.v
@@ -102,9 +102,6 @@ module iob2axi_tb;
 
       length = 1;
       addr = 4;
-
-      @(posedge  clk) #1;
-
       valid = 1;
       wdata = 2;
 

--- a/hardware/iob2axi/iob2axi_tb.v
+++ b/hardware/iob2axi/iob2axi_tb.v
@@ -244,25 +244,26 @@ module iob2axi_tb;
 
       valid = 0;
 
-      @(posedge  clk) #1;
-      @(posedge  clk) #1;
-      @(posedge  clk) #1;
-      @(posedge  clk) #1;
-      @(posedge  clk) #1;
+      $display("INFO: Individual tests completed!");
 
-      $finish;
+      repeat (10) @(posedge  clk) #1;
 
       // Number from which to start the incremental sequence to initialize the RAM
       seq_ini = 32;
 
       // Write
       length = TEST_SZ-1;
-      valid = 1;
       addr = 32'h4000;
       wstrb = -1;
+
+      @(posedge clk) #1;
+
+      valid = 1;
       for (i=0; i < TEST_SZ; i=i+1) begin
          wdata = i+seq_ini;
-         @(posedge clk) #1;
+         do
+            @(posedge clk) #1;
+         while(!ready);
       end
       valid = 0;
 
@@ -271,21 +272,26 @@ module iob2axi_tb;
 
       // Read
       length = TEST_SZ-1;
-      valid = 1;
-      addr = 32'h4000;
       wstrb = 0;
-      for (i=0; i < TEST_SZ+1; i=i+1) begin
-         if (i == TEST_SZ) begin
-            valid = 0;
-         end
+      addr = 32'h4000;
 
-         @(posedge clk) #1;
+      @(posedge clk) #1;
+
+      valid = 1;
+      for (i=0; i < TEST_SZ; i=i+1) begin
+         do
+            @(posedge clk) #1;
+         while(!ready);
+
          if (rdata != i+seq_ini) begin
             $display("ERROR: Test failed! At position %d, data=%h and rdata=%h.", i, i+seq_ini, rdata);
          end
       end
+      valid = 0;
 
       $display("INFO: Test completed successfully!");
+
+      repeat (10) @(posedge clk) #1;
 
       $finish;
    end

--- a/hardware/iob2axi/iob2axi_tb.v
+++ b/hardware/iob2axi/iob2axi_tb.v
@@ -129,9 +129,6 @@ module iob2axi_tb;
 
       length = 2;
       addr = 12;
-
-      @(posedge  clk) #1;
-
       valid = 1;
       wdata = 4;
 
@@ -163,9 +160,6 @@ module iob2axi_tb;
       length = 0;
       addr = 0;
       wstrb = 4'h0;
-
-      @(posedge  clk) #1;
-
       valid = 1;
 
       while(!ready)
@@ -183,9 +177,6 @@ module iob2axi_tb;
 
       length = 1;
       addr = 4;
-
-      @(posedge  clk) #1;
-
       valid = 1;
 
       while(!ready)
@@ -216,9 +207,6 @@ module iob2axi_tb;
 
       length = 2;
       addr = 12;
-
-      @(posedge  clk) #1;
-
       valid = 1;
 
       while(!ready)

--- a/hardware/iob2axi/iob2axi_tb.v
+++ b/hardware/iob2axi/iob2axi_tb.v
@@ -2,12 +2,14 @@
 
 `include "axi.vh"
 
+`define CLK_PER 1000
+
 module iob2axi_tb;
 
    parameter TEST_SZ = 256;
 
    parameter ADDR_W = 24;
-   parameter DATA_W = 128;
+   parameter DATA_W = 32;
 
    parameter AXI_ADDR_W = ADDR_W;
    parameter AXI_DATA_W = DATA_W;
@@ -77,13 +79,186 @@ module iob2axi_tb;
       // Test starts here
       //
 
+      // Test - 1 write
+      while(!iob2axi_ready)
+         @(posedge  clk) #1;
+
+      length = 0;
+      addr = 0;
+      valid = 1;
+      wstrb = 4'hf;
+      wdata = 1;
+
+      while(!ready)
+         @(posedge  clk) #1;
+
+      wdata = 0;
+      valid = 0;
+
+      repeat (4) @(posedge  clk) #1;
+      // Test - 2 writes with delay between
+      while(!iob2axi_ready)
+         @(posedge  clk) #1;
+
+      length = 1;
+      addr = 4;
+
+      @(posedge  clk) #1;
+
+      valid = 1;
+      wdata = 2;
+
+      while(!ready)
+         @(posedge  clk) #1;
+
+      wdata = 0;
+      valid = 0;
+
+      @(posedge  clk) #1;
+      @(posedge  clk) #1;
+
+      wdata = 3;
+      valid = 1;
+
+      while(!ready)
+         @(posedge  clk) #1;
+
+      wdata = 0;
+      valid = 0;
+
+      // Test - 3 writes in a row
+      while(!iob2axi_ready)
+         @(posedge  clk) #1;
+
+      length = 2;
+      addr = 12;
+
+      @(posedge  clk) #1;
+
+      valid = 1;
+      wdata = 4;
+
+      while(!ready)
+         @(posedge  clk) #1;
+
+      wdata = 5;
+
+      @(posedge  clk) #1;
+      while(!ready)
+         @(posedge  clk) #1;
+
+      wdata = 6;
+
+      @(posedge  clk) #1;
+
+      valid = 0;
+
+      @(posedge  clk) #1;
+      @(posedge  clk) #1;
+      @(posedge  clk) #1;
+      @(posedge  clk) #1;
+      @(posedge  clk) #1;
+
+      // Test - 1 read
+      while(!iob2axi_ready)
+         @(posedge  clk) #1;
+
+      length = 0;
+      addr = 0;
+      wstrb = 4'h0;
+
+      @(posedge  clk) #1;
+
+      valid = 1;
+
+      while(!ready)
+         @(posedge  clk) #1;
+
+      if(rdata != 1)
+         $display("Error on read 1, value given: %d\n",rdata);
+
+      valid = 0;
+
+      repeat (4) @(posedge  clk) #1;
+      // Test - 2 reads with delay between
+      while(!iob2axi_ready)
+         @(posedge  clk) #1;
+
+      length = 1;
+      addr = 4;
+
+      @(posedge  clk) #1;
+
+      valid = 1;
+
+      while(!ready)
+         @(posedge  clk) #1;
+
+      if(rdata != 2)
+         $display("Error on read 2, value given: %d\n",rdata);
+
+      wdata = 0;
+      valid = 0;
+
+      @(posedge  clk) #1;
+      @(posedge  clk) #1;
+
+      valid = 1;
+
+      while(!ready)
+         @(posedge  clk) #1;
+
+      if(rdata != 3)
+         $display("Error on read 3, value given: %d\n",rdata);
+
+      valid = 0;
+
+      // Test - 3 reads in a row
+      while(!iob2axi_ready)
+         @(posedge  clk) #1;
+
+      length = 2;
+      addr = 12;
+
+      @(posedge  clk) #1;
+
+      valid = 1;
+
+      while(!ready)
+         @(posedge  clk) #1;
+
+      if(rdata != 4)
+         $display("Error on read 4, value given: %d\n",rdata);
+
+      @(posedge  clk) #1;
+      while(!ready)
+         @(posedge  clk) #1;
+
+      if(rdata != 5)
+         $display("Error on read 5, value given: %d\n",rdata);         
+
+      @(posedge  clk) #1;
+
+      if(rdata != 6)
+         $display("Error on read 6, value given: %d\n",rdata);
+
+      valid = 0;
+
+      @(posedge  clk) #1;
+      @(posedge  clk) #1;
+      @(posedge  clk) #1;
+      @(posedge  clk) #1;
+      @(posedge  clk) #1;
+
+      $finish;
+
       // Number from which to start the incremental sequence to initialize the RAM
       seq_ini = 32;
 
       // Write
       length = TEST_SZ-1;
       valid = 1;
-      addr = 0x4000;
+      addr = 32'h4000;
       wstrb = -1;
       for (i=0; i < TEST_SZ; i=i+1) begin
          wdata = i+seq_ini;
@@ -97,7 +272,7 @@ module iob2axi_tb;
       // Read
       length = TEST_SZ-1;
       valid = 1;
-      addr = 0x4000;
+      addr = 32'h4000;
       wstrb = 0;
       for (i=0; i < TEST_SZ+1; i=i+1) begin
          if (i == TEST_SZ) begin
@@ -128,11 +303,23 @@ module iob2axi_tb;
       //
       // Native interface
       //
+      .s_valid(valid),
+      .s_addr(addr),
+      .s_wdata(wdata),
+      .s_wstrb(wstrb),
+      .s_rdata(rdata),
+      .s_ready(ready),
+
+      //
+      // Control I/F
+      //
+      .length(length),
+      .ready(iob2axi_ready),
+      .error(error),
 
       //
       // AXI-4 full master interface
       //
-
       `AXI4_IF_PORTMAP(m_, ddr_)
       );
 

--- a/hardware/iob2axi/iob2axi_wr.v
+++ b/hardware/iob2axi/iob2axi_wr.v
@@ -57,16 +57,13 @@ module iob2axi_wr
    reg                     m_axi_bready_int;
 
    // Control register signals
-   reg [ADDR_W-1:0]        addr_reg;
-   reg [`AXI_LEN_W-1:0]    length_reg;
-
    reg                     s_ready_int;
 
    // Write address
    assign m_axi_awid = `AXI_ID_W'd0;
    assign m_axi_awvalid = m_axi_awvalid_int;
-   assign m_axi_awaddr = addr_reg;
-   assign m_axi_awlen = length_reg;
+   assign m_axi_awaddr = s_addr;
+   assign m_axi_awlen = length;
    assign m_axi_awsize = axi_awsize;
    assign m_axi_awburst = `AXI_BURST_W'd1;
    assign m_axi_awlock = `AXI_LOCK_W'd0;
@@ -96,17 +93,6 @@ module iob2axi_wr
          error <= error_nxt;
          ready <= ready_nxt;
          s_ready <= s_ready_int;
-      end
-   end
-
-   // Control registers
-   always @(posedge clk, posedge rst) begin
-      if (rst) begin
-         addr_reg <= 1'b0;
-         length_reg <= 1'b0;
-      end else if (state == ADDR_HS) begin
-         addr_reg <= s_addr;
-         length_reg <= length;
       end
    end
 
@@ -173,7 +159,7 @@ module iob2axi_wr
            m_axi_wvalid_int = s_valid;
 
            if (m_axi_wready & s_valid) begin
-              if (counter == length_reg) begin
+              if (counter == length) begin
                  m_axi_wlast_int = 1'b1;
                  state_nxt = W_RESPONSE;
               end

--- a/hardware/iob2axi/iob2axi_wr.v
+++ b/hardware/iob2axi/iob2axi_wr.v
@@ -28,7 +28,7 @@ module iob2axi_wr
     input [ADDR_W-1:0]     s_addr,
     input [DATA_W-1:0]     s_wdata,
     input [DATA_W/8-1:0]   s_wstrb,
-    output                 s_ready,
+    output reg             s_ready,
 
     //
     // AXI-4 Full Master Write I/F
@@ -62,8 +62,6 @@ module iob2axi_wr
 
    reg                     s_ready_int;
 
-   assign s_ready = s_ready_int;
-
    // Write address
    assign m_axi_awid = `AXI_ID_W'd0;
    assign m_axi_awvalid = m_axi_awvalid_int;
@@ -92,10 +90,12 @@ module iob2axi_wr
          counter <= `AXI_LEN_W'd0;
          error <= 1'b0;
          ready <= 1'b1;
+         s_ready <= 1'b0;
       end else begin
          counter <= counter_nxt;
          error <= error_nxt;
          ready <= ready_nxt;
+         s_ready <= s_ready_int;
       end
    end
 
@@ -167,7 +167,7 @@ module iob2axi_wr
         end
         // Write data
         WRITE: begin
-           s_ready_int = m_axi_wready;
+           s_ready_int = (s_valid & m_axi_wready);
 
            m_axi_awvalid_int = awvalid_int;
            m_axi_wvalid_int = s_valid;

--- a/hardware/iob2axi/iob2axi_wr.v
+++ b/hardware/iob2axi/iob2axi_wr.v
@@ -57,6 +57,8 @@ module iob2axi_wr
    reg                     m_axi_bready_int;
 
    // Control register signals
+   reg [`AXI_LEN_W-1:0]    length_reg;
+
    reg                     s_ready_int;
 
    // Write address
@@ -93,6 +95,15 @@ module iob2axi_wr
          error <= error_nxt;
          ready <= ready_nxt;
          s_ready <= s_ready_int;
+      end
+   end
+
+   // Control registers
+   always @(posedge clk, posedge rst) begin
+      if (rst) begin
+         length_reg <= 1'b0;
+      end else if (state == ADDR_HS) begin
+         length_reg <= length;
       end
    end
 
@@ -159,7 +170,7 @@ module iob2axi_wr
            m_axi_wvalid_int = s_valid;
 
            if (m_axi_wready & s_valid) begin
-              if (counter == length) begin
+              if (counter == length_reg) begin
                  m_axi_wlast_int = 1'b1;
                  state_nxt = W_RESPONSE;
               end

--- a/hardware/iob2axi/waves.gtkw
+++ b/hardware/iob2axi/waves.gtkw
@@ -1,0 +1,61 @@
+[*]
+[*] GTKWave Analyzer v3.3.103 (w)1999-2019 BSI
+[*] Fri Feb  4 14:37:29 2022
+[*]
+[dumpfile] "(null)"
+[savefile] "/home/zettasticks/IOBundle/iob-soc-eth/submodules/ETHERNET/submodules/DMA/submodules/LIB/hardware/iob2axi/waves.gtkw"
+[timestart] 108360000
+[size] 1848 1016
+[pos] -1 -1
+*-23.000000 148540000 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
+[treeopen] iob2axi_tb.
+[treeopen] iob2axi_tb.uut.
+[sst_width] 258
+[signals_width] 286
+[sst_expanded] 1
+[sst_vpaned_height] 289
+@28
+iob2axi_tb.clk
+@200
+-NATIVE
+@28
+iob2axi_tb.uut.s_valid
+@22
+iob2axi_tb.uut.s_addr[23:0]
+iob2axi_tb.uut.s_wdata[31:0]
+iob2axi_tb.uut.s_wstrb[3:0]
+iob2axi_tb.uut.s_rdata[31:0]
+@28
+iob2axi_tb.uut.s_ready
+@22
+iob2axi_tb.uut.length[7:0]
+@28
+iob2axi_tb.uut.ready
+@200
+-AXI_WRITE
+@28
+iob2axi_tb.uut.m_axi_awvalid
+iob2axi_tb.uut.m_axi_awready
+@22
+iob2axi_tb.uut.m_axi_awaddr[23:0]
+iob2axi_tb.uut.m_axi_awlen[7:0]
+@28
+iob2axi_tb.uut.m_axi_wvalid
+iob2axi_tb.uut.m_axi_wready
+@22
+iob2axi_tb.uut.m_axi_wdata[31:0]
+@200
+-AXI_READ
+@28
+iob2axi_tb.uut.m_axi_arvalid
+iob2axi_tb.uut.m_axi_arready
+@22
+iob2axi_tb.uut.m_axi_araddr[23:0]
+iob2axi_tb.uut.m_axi_arlen[7:0]
+@28
+iob2axi_tb.uut.m_axi_rvalid
+iob2axi_tb.uut.m_axi_rready
+iob2axi_tb.uut.iob2axi_rd0.s_ready_int
+iob2axi_tb.uut.iob2axi_rd0.state
+[pattern_trace] 1
+[pattern_trace] 0

--- a/hardware/iob2axi/waves.gtkw
+++ b/hardware/iob2axi/waves.gtkw
@@ -1,12 +1,12 @@
 [*]
 [*] GTKWave Analyzer v3.3.103 (w)1999-2019 BSI
-[*] Fri Feb  4 15:02:10 2022
+[*] Fri Feb  4 17:16:08 2022
 [*]
 [dumpfile] "/home/zettasticks/IOBundle/iob-soc-eth/submodules/ETHERNET/submodules/DMA/submodules/LIB/hardware/iob2axi/uut.vcd"
-[dumpfile_mtime] "Fri Feb  4 14:52:46 2022"
-[dumpfile_size] 168547
+[dumpfile_mtime] "Fri Feb  4 17:15:49 2022"
+[dumpfile_size] 168065
 [savefile] "/home/zettasticks/IOBundle/iob-soc-eth/submodules/ETHERNET/submodules/DMA/submodules/LIB/hardware/iob2axi/waves.gtkw"
-[timestart] 118890000
+[timestart] 118870000
 [size] 1848 1016
 [pos] -1 -1
 *-23.000000 112380000 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
@@ -28,6 +28,9 @@ iob2axi_tb.uut.s_wdata[31:0]
 iob2axi_tb.uut.s_rdata[31:0]
 iob2axi_tb.uut.s_wstrb[3:0]
 iob2axi_tb.uut.s_addr[23:0]
+@23
+iob2axi_tb.length[7:0]
+@22
 iob2axi_tb.uut.length[7:0]
 @200
 -AXI_WRITE

--- a/hardware/iob2axi/waves.gtkw
+++ b/hardware/iob2axi/waves.gtkw
@@ -1,13 +1,15 @@
 [*]
 [*] GTKWave Analyzer v3.3.103 (w)1999-2019 BSI
-[*] Fri Feb  4 14:37:29 2022
+[*] Fri Feb  4 14:50:44 2022
 [*]
-[dumpfile] "(null)"
+[dumpfile] "/home/zettasticks/IOBundle/iob-soc-eth/submodules/ETHERNET/submodules/DMA/submodules/LIB/hardware/iob2axi/uut.vcd"
+[dumpfile_mtime] "Fri Feb  4 14:50:12 2022"
+[dumpfile_size] 11713946
 [savefile] "/home/zettasticks/IOBundle/iob-soc-eth/submodules/ETHERNET/submodules/DMA/submodules/LIB/hardware/iob2axi/waves.gtkw"
-[timestart] 108360000
+[timestart] 673690000
 [size] 1848 1016
 [pos] -1 -1
-*-23.000000 148540000 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
+*-23.000000 686480000 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
 [treeopen] iob2axi_tb.
 [treeopen] iob2axi_tb.uut.
 [sst_width] 258
@@ -55,6 +57,9 @@ iob2axi_tb.uut.m_axi_arlen[7:0]
 @28
 iob2axi_tb.uut.m_axi_rvalid
 iob2axi_tb.uut.m_axi_rready
+@23
+iob2axi_tb.uut.iob2axi_rd0.m_axi_rdata[31:0]
+@28
 iob2axi_tb.uut.iob2axi_rd0.s_ready_int
 iob2axi_tb.uut.iob2axi_rd0.state
 [pattern_trace] 1

--- a/hardware/iob2axi/waves.gtkw
+++ b/hardware/iob2axi/waves.gtkw
@@ -1,15 +1,15 @@
 [*]
 [*] GTKWave Analyzer v3.3.103 (w)1999-2019 BSI
-[*] Fri Feb  4 14:50:44 2022
+[*] Fri Feb  4 15:02:10 2022
 [*]
 [dumpfile] "/home/zettasticks/IOBundle/iob-soc-eth/submodules/ETHERNET/submodules/DMA/submodules/LIB/hardware/iob2axi/uut.vcd"
-[dumpfile_mtime] "Fri Feb  4 14:50:12 2022"
-[dumpfile_size] 11713946
+[dumpfile_mtime] "Fri Feb  4 14:52:46 2022"
+[dumpfile_size] 168547
 [savefile] "/home/zettasticks/IOBundle/iob-soc-eth/submodules/ETHERNET/submodules/DMA/submodules/LIB/hardware/iob2axi/waves.gtkw"
-[timestart] 673690000
+[timestart] 118890000
 [size] 1848 1016
 [pos] -1 -1
-*-23.000000 686480000 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
+*-23.000000 112380000 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
 [treeopen] iob2axi_tb.
 [treeopen] iob2axi_tb.uut.
 [sst_width] 258
@@ -22,17 +22,13 @@ iob2axi_tb.clk
 -NATIVE
 @28
 iob2axi_tb.uut.s_valid
-@22
-iob2axi_tb.uut.s_addr[23:0]
-iob2axi_tb.uut.s_wdata[31:0]
-iob2axi_tb.uut.s_wstrb[3:0]
-iob2axi_tb.uut.s_rdata[31:0]
-@28
 iob2axi_tb.uut.s_ready
 @22
+iob2axi_tb.uut.s_wdata[31:0]
+iob2axi_tb.uut.s_rdata[31:0]
+iob2axi_tb.uut.s_wstrb[3:0]
+iob2axi_tb.uut.s_addr[23:0]
 iob2axi_tb.uut.length[7:0]
-@28
-iob2axi_tb.uut.ready
 @200
 -AXI_WRITE
 @28
@@ -57,10 +53,7 @@ iob2axi_tb.uut.m_axi_arlen[7:0]
 @28
 iob2axi_tb.uut.m_axi_rvalid
 iob2axi_tb.uut.m_axi_rready
-@23
+@22
 iob2axi_tb.uut.iob2axi_rd0.m_axi_rdata[31:0]
-@28
-iob2axi_tb.uut.iob2axi_rd0.s_ready_int
-iob2axi_tb.uut.iob2axi_rd0.state
 [pattern_trace] 1
 [pattern_trace] 0


### PR DESCRIPTION
"make sim-waves" in the iob2axi folder should run the simulation that passes successfully and produces the vcd where the signals follow the native interface correctly.

Didn't test on the board, only simulation, but eventually I'll need to use this on the ethernet module, after the DMA changes, and in that time I'll test it fully.