### PR TITLE
feat(sw): _SET() _GET() macros are functions in PC

### DIFF
--- a/software/include/iob-lib.h
+++ b/software/include/iob-lib.h
@@ -1,3 +1,4 @@
+#ifndef PC
 //memory access macros
 #define MEM_SET(type, location, value) (*((type*) (location)) = value)
 #define MEM_GET(type, location)        (*((type*) (location)))
@@ -5,4 +6,13 @@
 //stream access macros
 #define IO_SET(base, location, value) (*((volatile int*) (base + (sizeof(int)) * location)) = value)
 #define IO_GET(base, location)        (*((volatile int*) (base + (sizeof(int)) * location)))
+#else // ifdef PC
+//memory access functions
+void MEM_SET(int type, int location, int value);
+int MEM_GET(int type, int location);
+
+//stream access functions
+void IO_SET(int base, int location, int value);
+int IO_GET(int base, int location);
+#endif
 


### PR DESCRIPTION
- Update `iob-lib.h` macros to be function declaration for pc-emul case.
- Keep same behaviour as before for embedded drivers