### PR TITLE
fix(sw): Fix iob-lib.h macros

### DIFF
--- a/software/include/iob-lib.h
+++ b/software/include/iob-lib.h
@@ -1,11 +1,11 @@
 #ifndef PC
 //memory access macros
-#define MEM_SET(type, location, value) (*((type*) (location)) = value)
+#define MEM_SET(type, location, value) (*((type*) (location)) = (value) )
 #define MEM_GET(type, location)        (*((type*) (location)))
 
 //stream access macros
-#define IO_SET(base, location, value) (*((volatile int*) (base + (sizeof(int)) * location)) = value)
-#define IO_GET(base, location)        (*((volatile int*) (base + (sizeof(int)) * location)))
+#define IO_SET(base, location, value) (*((volatile int*) ( (base) + (sizeof(int)) * (location) )) = (value) )
+#define IO_GET(base, location)        (*((volatile int*) ( (base) + (sizeof(int)) * (location) )))
 #else // ifdef PC
 //memory access functions
 void MEM_SET(int type, int location, int value);


### PR DESCRIPTION
- Fix macros in iob-lib.h, some macro parameters where not inside parenthesis
- This could lead to weird bugs, for example with:
```C
// Old macro
#define IO_SET(base, location, value) (*((volatile int*) (base + (sizeof(int)) * location)) = value)
// Example Problematic usage
for(i=0; i<N; i++)
    IO_SET(base, SOME_REG + i, new_val[i]);
// Expands to:
for(i=0; i<N; i++)
    (*((volatile int*) (base + (sizeof(int)) * SOME_REG + i)) = new_val[i]);
```
- Notice how only `SOME_REG` gets multiplied by `sizeof(int)`, instead of the expected `sizeof(int) * ( SOME_REG + i)` behaviour.
- This leads to inconsistent access patterns.
- With the old macro the CPU would access a peripheral core:
```
    - core[SOME_REG + 0] = new_val[0]
    - core[SOME_REG + 0] = new_val[1]
    - core[SOME_REG + 0] = new_val[2]
    - core[SOME_REG + 0] = new_val[3]
    - core[SOME_REG + 1] = new_val[4]
    - ...
```
- Instead of the expected:
```
    - core[SOME_REG + 0] = new_val[0]
    - core[SOME_REG + 1] = new_val[1]
    - core[SOME_REG + 2] = new_val[2]
    - core[SOME_REG + 3] = new_val[3]
    - core[SOME_REG + 4] = new_val[4]
    - ...
```