### PR TITLE
fix(sw): static function declaration for pc-emul

### DIFF
--- a/software/include/iob-lib.h
+++ b/software/include/iob-lib.h
@@ -8,11 +8,11 @@
 #define IO_GET(base, location)        (*((volatile int*) ( (base) + (sizeof(int)) * (location) )))
 #else // ifdef PC
 //memory access functions
-void MEM_SET(int type, int location, int value);
-int MEM_GET(int type, int location);
+static void MEM_SET(int type, int location, int value);
+static int MEM_GET(int type, int location);
 
 //stream access functions
-void IO_SET(int base, int location, int value);
-int IO_GET(int base, int location);
+static void IO_SET(int base, int location, int value);
+static int IO_GET(int base, int location);
 #endif
 


### PR DESCRIPTION
- Declare functions in `iob-lib.h` as static
- This is needed so that each core drivers can have a different
  implementation for the functions
- For example if we have a system with a TIMER and ETHERNET core each
  peripheral has a implementation of the `IO_GET()` and `IO_SET()`
  functions for the pc-emul case.
  Declaring the functions as static allows for a different
  implementation per peripheral.
  This change restricts the usage of the
  `MEM_SET()/MEM_GET()/IO_SET()/IO_GET()` macros/functions to the common
  software driver code of each peripheral (software/iob-timer.c and
  software/iob-eth.c for the timer and ethernet peripherals
  respectively)
- This change also requires updating the embedded/pc-emul specific files
  to a `iob-CORE-platform.h` file that is included in the common driver
  file.