### PR TITLE
Fix bug in mkregs.py

### DIFF
--- a/software/python/mkregs.py
+++ b/software/python/mkregs.py
@@ -166,10 +166,12 @@ def get_core_addr_w(table):
             else:
                 max_addr_from_mem = 0
 
+
     if max_addr_from_mem:
         max_addr = max_addr + int(get_mem_range(table)) 
 
-    hw_max_addr = max_addr >> 2
+    hw_max_addr = (max_addr >> 2) + 1
+
     addr_w = int(math.ceil(math.log(hw_max_addr, 2)))
     return addr_w
 


### PR DESCRIPTION
The `hw_max_addr` needs to be incremented by 1 to include the register
with address "0" (The first register in the `table` list).

For example, without this fix, an error occurs trying to build a peripheral with only one register:
The register will have address 0, therefore `hw_max_addr` will be 0 and
`math.log(0,2)` will throw an error.