### PR TITLE
feat(Mkregs): Update mkregs format, minor fixes to docs

### DIFF
--- a/document/pb/pb.cls
+++ b/document/pb/pb.cls
@@ -35,7 +35,7 @@
 \renewcommand{\headrulewidth}{.4pt}
 \fancyhead{}
 \fancyhead[RO,LE]{
-\textbf{\@title}
+\textbf{\@header}
 \\
 \textsc{\small{\@category}}
 }

--- a/document/pb/pb.cls
+++ b/document/pb/pb.cls
@@ -53,6 +53,7 @@
 %}
 
 \newcommand{\category}[1]{\def\@category{#1}}
+\newcommand{\header}[1]{\def\@header{#1}}
 \renewcommand{\familydefault}{\sfdefault}
 
 \renewcommand{\maketitle}{

--- a/hardware/include/iob_lib.vh
+++ b/hardware/include/iob_lib.vh
@@ -5,7 +5,7 @@
 `define IOB_MAX(a,b) {((a) > (b)) ? (a) : (b)}
 `define IOB_MIN(a,b) {((a) < (b)) ? (a) : (b)}
 `define IOB_ABS(a, w) {a[w-1]? (-a): (a)}
-`define IOB_MUX2(SEL, OUT, IN1, IN2) assign OUT = SET==1'b0? IN1 : IN2;
+`define IOB_MUX2(SEL, OUT, IN1, IN2) assign OUT = SEL==1'b0? IN1 : IN2;
 `define IOB_COMB always @*
 `define IOB_MUX(SEL, OUT, IN) `IOB_COMB OUT = IN[SEL];
 

--- a/software/python/mkregs.py
+++ b/software/python/mkregs.py
@@ -179,7 +179,6 @@ def gen_mem_read_hw(table, fout):
 
     # switch case for mem reads
     num_read_mems = get_num_mem_type(table, "R")
-    fout.write(f"\n`IOB_WIRE(mem_switch, {num_read_mems})\n")
     fout.write(f"`IOB_WIRE(mem_switch_reg, {num_read_mems})\n")
     mem_read_en_concat_str = "}"
     first_reg = 1
@@ -284,6 +283,8 @@ def write_hw(table, regfile_name):
         fout.write("//Select read data from registers or memory\n")
         fout.write("`IOB_VAR(mem_rdata_int, DATA_W)\n")
         fout.write("`IOB_WIRE(mem_read_sel_reg, 1)\n")
+        num_read_mems = get_num_mem_type(table, "R")
+        fout.write(f"\n`IOB_WIRE(mem_switch, {num_read_mems})\n")
         # Register condition for SWMEM_R access
         fout.write("iob_reg #(1) mem_read_sel_ (clk, rst, 1'b0, 1'b0, 1'b0, 1'b1, (valid & (wstrb == 0) & |mem_switch), mem_read_sel_reg);\n")
         # skip rdata_int2 delay for memory read accesses

--- a/software/python/mkregs.py
+++ b/software/python/mkregs.py
@@ -641,8 +641,6 @@ def calc_swreg_addr(table, cpu_nbytes=4):
                 read_addr = reg_addr + reg_nbytes
             elif reg['rw_type'] == "W" and write_addr <= reg_addr:
                 write_addr = reg_addr + reg_nbytes
-            else:
-                print(f"Error: invalid RW type for {reg['name']}")
 
     # Assign automatic addresses
     reg_addr = 0

--- a/software/python/mkregs.py
+++ b/software/python/mkregs.py
@@ -4,9 +4,8 @@
 #
 
 import sys
-from parse import search
+from parse import parse, search
 import math
-from verilog2tex import header_parse
 
 
 def print_usage():
@@ -79,6 +78,35 @@ def print_help():
     IOB_SWMEM_R(CORE_READ_BUFFER, 16, 10)//Core read buffer"""
 
     print(help_str)
+
+
+def header_parse (vh, defines):
+    """ Parse header files
+    """
+
+    for line in vh:
+        d_flds = parse('`define {} {}\n', line.lstrip(' '))
+
+        if d_flds is None:
+            continue #not a macro
+
+        #NAME
+        name = d_flds[0].lstrip(' ')
+
+        #VALUE
+        eval_str = d_flds[1].strip('`').lstrip(' ').replace("$", "") #to replace $clog2 with clog2
+        for key, val in defines.items():
+            eval_str = eval_str.replace(str(key),str(val))
+
+        try:
+            value = eval(eval_str)
+        except:
+            #eval_str has undefined parameters: use as is
+            value = eval_str
+
+        #insert in dictionary
+        if name not in defines:
+            defines[name] = value
 
 
 def has_mem_type(table, mem_type_list=["W", "R"]):

--- a/software/python/mkregs.py
+++ b/software/python/mkregs.py
@@ -430,6 +430,18 @@ def write_swheader(table, regfile_name, core_prefix, defines):
         if row["rw_type"] == "R":
             fout.write(f"#define {row['name']} {row['addr']}\n")
 
+    fout.write("\n//register/memory data widths (bit)\n")
+
+    fout.write("//Write Register/Memory\n")
+    for row in table:
+        if row["rw_type"] == "W":
+            fout.write(f"#define {row['name']}_W {int(row['nbytes'])*8}\n")
+
+    fout.write("//Read Register/Memory\n")
+    for row in table:
+        if row["rw_type"] == "R":
+            fout.write(f"#define {row['name']}_W {int(row['nbytes'])*8}\n")
+
     fout.write("\n// Base Address\n")
     fout.write(f"void {core_prefix}_INIT_BASEADDR(uint32_t addr);\n")
 

--- a/software/python/verilog2tex.py
+++ b/software/python/verilog2tex.py
@@ -6,6 +6,8 @@ import sys
 import os
 from parse import parse
 
+import mkregs
+
 '''
 Parse header files
 '''
@@ -220,11 +222,30 @@ def io_parse (io_lines, params, defines):
         write_table(table_name + '_if', table)
 
 
+def get_swreg_by_name(swreg_list, name):
+    for swreg in swreg_list:
+        if 'name' in swreg and swreg['name'] == name:
+            return swreg
+
+    return None
+
 def swreg_parse (vh, defines) :
 
     swreg_cnt = 0
     table_found = 0
     table = []
+
+    # get all swregs from mkregs_conf with addresses pre calculated
+    swreg_list = []
+    for line in vh:
+        swreg_flds = mkregs.swreg_get_fields(line)
+        if swreg_flds is None:
+            continue
+
+        swreg_list.append(swreg_flds)
+
+    # calculate address field
+    swreg_list = mkregs.calc_swreg_addr(swreg_list)
 
     for line in vh:
 
@@ -239,27 +260,27 @@ def swreg_parse (vh, defines) :
             continue
 
         swreg_flds = []
-        swreg_flds_tmp = parse('{}IOB_SWREG_{}({},{},{}){}//{}', line)
+        swreg_dict = mkregs.swreg_get_fields(line)
+        if swreg_dict is None:
+            continue
 
-        if swreg_flds_tmp is None:
-            swreg_flds_tmp = parse('IOB_SWREG_{}({},{},{}){}//{}', line)
-            if swreg_flds_tmp is None: continue #not a sw reg
-        else:
-            swreg_flds_tmp = swreg_flds_tmp[1:]
+        swreg_dict = get_swreg_by_name(swreg_list, swreg_dict['name'])
+        if swreg_dict is None:
+            continue
 
         #NAME
-        swreg_flds.append(swreg_flds_tmp[1].replace('_','\_').strip(' '))
+        swreg_flds.append(swreg_dict['name'].replace('_','\_'))
 
         #TYPE
-        swreg_flds.append(swreg_flds_tmp[0])
+        swreg_flds.append(swreg_dict['rw_type'])
 
         #ADDRESS
-        swreg_flds.append(4*swreg_cnt)
-        swreg_cnt = swreg_cnt + 1
+        swreg_flds.append(swreg_dict['addr'])
 
         #WIDTH
         #may be defined using macros: replace and evaluate
-        eval_str = swreg_flds_tmp[2].replace('`','').replace(',','')
+        tmp_width = f"{int(swreg_dict['nbytes'])*8}"
+        eval_str = tmp_width.replace('`','').replace(',','')
         for key, val in defines.items():
             eval_str = eval_str.replace(str(key),str(val))
         try:
@@ -269,10 +290,10 @@ def swreg_parse (vh, defines) :
             swreg_flds.append(eval_str.replace('_','\_').strip(' '))
 
         #DEFAULT VALUE
-        swreg_flds.append(swreg_flds_tmp[3])
+        swreg_flds.append(swreg_dict['default_value'])
 
         #DESCRIPTION
-        swreg_flds.append(swreg_flds_tmp[5].replace('_','\_'))
+        swreg_flds.append(swreg_dict['description'].replace('_','\_'))
 
         table.append(swreg_flds)
 

--- a/software/python/verilog2tex.py
+++ b/software/python/verilog2tex.py
@@ -6,36 +6,8 @@ import sys
 import os
 from parse import parse
 
-import mkregs
+from mkregs import calc_swreg_addr, swreg_get_fields, header_parse
 
-'''
-Parse header files
-'''
-def header_parse (vh, defines):
-
-    for line in vh:
-        d_flds = parse('`define {} {}\n', line.lstrip(' '))
-
-        if d_flds is None:
-            continue #not a macro
-
-        #NAME
-        name = d_flds[0].lstrip(' ')
-
-        #VALUE
-        eval_str = d_flds[1].strip('`').lstrip(' ').replace("$", "") #to replace $clog2 with clog2
-        for key, val in defines.items():
-            eval_str = eval_str.replace(str(key),str(val))
-
-        try:
-            value = eval(eval_str)
-        except:
-            #eval_str has undefined parameters: use as is
-            value = eval_str
-
-        #insert in dictionary
-        if name not in defines:
-            defines[name] = value
 
 '''
 Write Latex table
@@ -238,14 +210,14 @@ def swreg_parse (vh, defines) :
     # get all swregs from mkregs_conf with addresses pre calculated
     swreg_list = []
     for line in vh:
-        swreg_flds = mkregs.swreg_get_fields(line)
+        swreg_flds = swreg_get_fields(line)
         if swreg_flds is None:
             continue
 
         swreg_list.append(swreg_flds)
 
     # calculate address field
-    swreg_list = mkregs.calc_swreg_addr(swreg_list)
+    swreg_list = calc_swreg_addr(swreg_list)
 
     for line in vh:
 
@@ -260,7 +232,7 @@ def swreg_parse (vh, defines) :
             continue
 
         swreg_flds = []
-        swreg_dict = mkregs.swreg_get_fields(line)
+        swreg_dict = swreg_get_fields(line)
         if swreg_dict is None:
             continue
 


### PR DESCRIPTION
- Update mkregs:
  - `mkregs.conf` supports new unified `IOB_SWREG` macro for both REGs and MEMs
  - independent read and write addressing scheme
  - support for manual addressing to each register/memory
  - generates wires and aligns with byte addressable data
  - CORE developper needs to connect generated wires with internal logic
  - check `./software/python/mkregs.py --help` for more information
## Example mkregs.conf
```Verilog
//START_SWREG_TABLE uart
IOB_SWREG_W(UART_SOFTRESET, 1, 0, -1, 0) //Bit duration in system clock cycles.
IOB_SWREG_W(UART_DIV, 2, 0, -1, 0) //Bit duration in system clock cycles.
IOB_SWREG_W(UART_TXDATA, 1, 0, -1, 0) //TX data
IOB_SWREG_W(UART_TXEN, 1, 0, -1, 0) //TX enable.
IOB_SWREG_R(UART_TXREADY, 1, 0, 0, 0) //TX ready to receive data
IOB_SWREG_R(UART_RXDATA, 1, 0, 4, 0) //RX data
IOB_SWREG_W(UART_RXEN, 1, 0, -1, 0) //RX enable.
IOB_SWREG_R(UART_RXREADY, 1, 0, 1, 0) //RX data is ready to be read.
```