### PR TITLE
Fix bug in 'mkregs.py' 

### DIFF
--- a/software/python/mkregs.py
+++ b/software/python/mkregs.py
@@ -343,7 +343,7 @@ def get_core_addr_w(table, cpu_nbytes=4):
         if last_addr > max_addr:
             max_addr = last_addr
 
-    hw_max_addr = math.floor((max_addr+1)/cpu_nbytes)
+    hw_max_addr = math.floor(max_addr/cpu_nbytes)+1
 
     addr_w = int(math.ceil(math.log(hw_max_addr, 2)))
     return addr_w

--- a/software/python/mkregs.py
+++ b/software/python/mkregs.py
@@ -345,7 +345,7 @@ def get_core_addr_w(table, cpu_nbytes=4):
 
     hw_max_addr = math.floor(max_addr/cpu_nbytes)+1
 
-    addr_w = int(math.ceil(math.log(hw_max_addr, 2)))
+    addr_w = max(int(math.ceil(math.log(hw_max_addr, 2))),1)
     return addr_w
 
 


### PR DESCRIPTION
Line 346: 
The increment to hw_max_addr should be done outside the math.floor() function, this guarantees that hw_max_addr is at least 1.
Without this fix, an error occurs when max_addr is less than cpu_nbytes (for example in a peripheral with only one register), because the value of hw_max_addr would be 0 and causing math.log(0,2).

Line 348: 
The return value addr_w should be at least 1 bit wide, since it will be used to generate the ```"`define {regfile_name}_ADDR_W {get_core_addr_w(table, cpu_nbytes)}\n\n"``` (line 359) verilog macro, that can only be greater than zero.
Without this fix, when addr_w is zero (for example in a peripheral with only one register) (I will use a UART with only one register here as an example), the value used when calling the line ```.address(slaves_req[`address(`UART0,`iob_uart_swreg_ADDR_W+2)-2]),``` (located inst.vh file of peripheral) will translate to ```.address(slaves_req[`address(`UART0,0+2)-2]),``` and that would give an error.
