### PR TITLE
feat(build): Minor improvements to build system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ BUILD_TSRC_DIR:=$(BUILD_DOC_DIR)/tsrc
 BUILD_FIG_DIR:=$(BUILD_DOC_DIR)/figures
 BUILD_SYN_DIR:=$(BUILD_DIR)/hw/syn
 
-# creat build directory
+# create build directory
 $(BUILD_DIR):
 	cp -r build $@
 
@@ -58,11 +58,11 @@ endif
 	cp $(CORE_SIM_DIR)/*.expected $(BUILD_SIM_DIR)
 ifneq ($(wildcard $(CORE_SIM_DIR)/*.mk),)
 	cp $(CORE_SIM_DIR)/*.mk $(BUILD_SIM_DIR)
-endif 
+endif
+	cp $(CORE_SIM_DIR)/*_tb.* $(BUILD_VSRC_DIR)
 ifneq ($(wildcard $(CORE_FPGA_DIR)/*.mk),)
 	cp $(CORE_FPGA_DIR)/*.mk $(BUILD_FPGA_DIR)
 endif
-	cp $(CORE_SIM_DIR)/*_tb.* $(BUILD_VSRC_DIR)
 	cp $(CORE_FPGA_DIR)/*.expected $(BUILD_FPGA_DIR)
 ifneq ($(wildcard $(CORE_FPGA_DIR)/*.sdc),)
 	cp $(CORE_FPGA_DIR)/*.sdc $(BUILD_FPGA_DIR)

--- a/build/Makefile
+++ b/build/Makefile
@@ -47,18 +47,18 @@ fpga-debug:
 #
 # DOCUMENT
 #
-DOC?=pb
+DOC_DIR=doc
 doc-build: 
-	make -C doc $(DOC).pdf
+	make -C $(DOC_DIR) build
 
 doc-test: 
-	make -C doc test
+	make -C $(DOC_DIR) test
 
 doc-clean: 
-	make -C doc clean
+	make -C $(DOC_DIR) clean
 
 doc-debug: 
-	make -C doc debug
+	make -C $(DOC_DIR) debug
 
 #
 # TEST

--- a/build/doc/Makefile
+++ b/build/doc/Makefile
@@ -11,12 +11,17 @@ ifneq ($(wildcard document.mk),)
 include document.mk
 endif
 
+#default DOC
+DOC?=pb
+
 $(NAME)_version.txt:
 	echo $(VERSION) > version.txt
 
 
 SW_DIR:=../sw
 PYTHON_DIR:=$(SW_DIR)/python
+
+build: $(DOC).pdf
 
 presentation.pdf: presentation.tex
 	pdflatex $<

--- a/build/hw/sim/Makefile
+++ b/build/hw/sim/Makefile
@@ -17,11 +17,7 @@ VSRC+=$(wildcard ../vsrc/*.v)
 #select simulator
 #default simulator
 SIMULATOR?=icarus
-ifeq ($(SIMULATOR), verilator)
-include verilator.mk
-else
-include icarus.mk
-endif
+include $(SIMULATOR).mk
 
 build: $(VHDR) $(VSRC)
 ifeq ($(SIM_SERVER),)

--- a/software/python/version.py
+++ b/software/python/version.py
@@ -2,20 +2,17 @@
 
 import sys
 
-if len(sys.argv) != 3:
-    sys.exit()
-core_name = sys.argv[1]
-core_version = sys.argv[2]
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        usage_str = """Usage: ./version.py NAME VERSION
+        NAME: core name
+        VERSION: core version. Format: 1234 -> V12.34"""
+        print(usage_str, file=sys.stderr)
+        sys.exit()
+    core_name = sys.argv[1]
+    core_version = sys.argv[2]
 
-print("V{}.{}".format(int(core_version[:2]),core_version[2:]))
+    print(f"V{int(core_version[:2])}.{int(core_version[2:])}")
 
-f = open("./{}_version.vh".format(core_name), "w+")
-
-f.write("`define VERSION {}".format(core_version))
-
-f.close()
-
-
-
-
-
+    with open("./{}_version.vh".format(core_name), "w+") as f:
+        f.write("`define VERSION {}".format(core_version))


### PR DESCRIPTION
- add usage and minor fix to version format in `version.py` script
- LIB/Makefile:
    - update copy order in setup target
    - use `DOC_DIR`, add `build` target for documents
    - move default `DOC` type to `build/doc/Makefile` to follow same
      process as simulation and fpga

### Other potential improvements / Ideas
- move tests targets and `test.expected` to custom makefile segments
    - current setup assumes that tests should be performed by comparing a `test.log` with a `test.expected` file 
    - test.log comparison is not what we want in the general case
    - remove copying `test.expected` from LIB/Makefile
- example for `fpga-run` targets:
    - how to support multiple fpga top levels, for example? Currently all verilog source files are copied to the same folder and added as sources for synthesis
    - Idea: create a separated build directory tree for each makefile flow (icarus, verilog, CycloneV, XCKU, documentation). Or at least a separated source directory for each simulator, fpga device, documentation, etc
