### PR TITLE
Add iob_ram_2p_be verilog module

### DIFF
--- a/hardware/ram/iob_ram_2p_be/hardware.mk
+++ b/hardware/ram/iob_ram_2p_be/hardware.mk
@@ -1,0 +1,11 @@
+ifneq ($(ASIC),1)
+ifeq ($(filter iob_ram_2p_be, $(HW_MODULES)),)
+
+# Add to modules list
+HW_MODULES+=iob_ram_2p_be
+
+# Sources
+VSRC+=$(MEM_DIR)/hardware/ram/iob_ram_2p_be/iob_ram_2p_be.v
+
+endif
+endif

--- a/hardware/ram/iob_ram_2p_be/iob_ram_2p_be.v
+++ b/hardware/ram/iob_ram_2p_be/iob_ram_2p_be.v
@@ -1,0 +1,49 @@
+`timescale 1ns/1ps
+
+module iob_ram_2p_be
+  #( 
+     parameter HEXFILE = "none",
+     parameter DATA_W = 0,
+     parameter ADDR_W = 0
+     ) 
+   (
+    input                   clk,
+
+    //write port
+    input [DATA_W/8-1:0]    w_en,
+    input [ADDR_W-1:0]      w_addr,
+    input [DATA_W-1:0]      w_data,
+
+    //read port
+    input                   r_en,
+    input [ADDR_W-1:0]      r_addr,
+    output reg [DATA_W-1:0] r_data
+    );
+
+   //this allows ISE 14.7 to work; do not remove
+   localparam mem_init_file_int = HEXFILE;
+
+   // Declare the RAM
+   reg [DATA_W-1:0]         mem [(2**ADDR_W)-1:0];
+
+   // Initialize the RAM
+   initial
+     if(mem_init_file_int != "none")
+       $readmemh(mem_init_file_int, mem, 0, (2**ADDR_W) - 1);
+
+   //read port
+   always @(posedge clk)
+      if(r_en)
+        r_data <= mem[r_addr];
+
+   //write port
+   genvar c;
+   generate
+      for (c = 0; c < DATA_W/8; c = c + 1) begin
+         always @(posedge clk)
+           if(w_en[c])
+             mem[w_addr][c+:8] <= w_data[c+:8];
+      end
+   endgenerate
+
+endmodule   

--- a/hardware/ram/iob_ram_2p_be/iob_ram_2p_be.v
+++ b/hardware/ram/iob_ram_2p_be/iob_ram_2p_be.v
@@ -36,14 +36,20 @@ module iob_ram_2p_be
       if(r_en)
         r_data <= mem[r_addr];
 
-   //write port
+   // Wires for internal manipulation of byte enable
+   wire [DATA_W-1:0] w_data_int;
+   wire [DATA_W-1:0] mem_output = mem[w_addr];
+   // Mux to keep current value or get new one based on byte enable
    genvar c;
    generate
       for (c = 0; c < DATA_W/8; c = c + 1) begin
-         always @(posedge clk)
-           if(w_en[c])
-             mem[w_addr][c+:8] <= w_data[c+:8];
+         assign w_data_int[c*8+:8] = w_en[c] ? w_data[c*8+:8] : mem_output[c*8+:8];
       end
    endgenerate
+
+   //write port
+   always @(posedge clk)
+     if(|w_en)
+       mem[w_addr] <= w_data_int;
 
 endmodule   

--- a/hardware/ram/iob_ram_2p_be/iob_ram_2p_be_tb.v
+++ b/hardware/ram/iob_ram_2p_be/iob_ram_2p_be_tb.v
@@ -1,0 +1,113 @@
+`timescale 1ns / 1ps
+
+`define DATA_W 8
+`define ADDR_W 4
+
+module iob_ram_2p_be_tb;
+
+   // Inputs
+   reg clk;
+
+   // Write signals
+   reg w_en;
+   reg [`DATA_W-1:0] w_data;
+   reg [`ADDR_W-1:0] w_addr;
+
+
+   // Read signals
+   reg               r_en;
+   reg [`ADDR_W-1:0] r_addr;
+   wire [`DATA_W-1:0] r_data;
+
+   integer            i, seq_ini;
+
+   parameter clk_per = 10; // clk period = 10 timeticks
+
+   initial begin
+      clk = 1;
+      r_en = 0;
+      w_en = 0;
+      r_addr = 0;
+      w_addr = 0;
+      w_data = 0;
+
+      // Number from which to start the incremental sequence to write into the RAM
+      seq_ini = 32;
+
+      // optional VCD
+`ifdef VCD
+      $dumpfile("uut.vcd");
+      $dumpvars();
+`endif
+
+      @(posedge clk) #1;
+      w_en = 1;
+
+      // Write all the locations of RAM
+      for(i = 0; i < 2**`ADDR_W; i = i + 1) begin
+         w_data = i+seq_ini;
+         w_addr = i;
+         @(posedge clk) #1;
+      end
+
+      w_en = 0;
+      @(posedge clk) #1;
+
+      // Read all the locations of RAM with r_en = 0
+      r_en = 0;
+      @(posedge clk) #1;
+
+      for(i = 0; i < 2**`ADDR_W; i = i + 1) begin
+         r_addr = i;
+         @(posedge clk) #1;
+         if(r_data != 0) begin
+            $display("ERROR: with r_en = 0, at position %0d, r_data should be 0 but is %d", i, r_data);
+            $finish;
+         end
+      end
+
+      r_en = 1;
+      @(posedge clk) #1;
+
+      // Read all the locations of RAM with r_en = 1
+      for(i = 0; i < 2**`ADDR_W; i = i + 1) begin
+         r_addr = i;
+         @(posedge clk) #1;
+         if(r_data != i+seq_ini) begin
+            $display("ERROR: on position %0d, r_data is %d where it should be %0d", i, r_data, i+seq_ini);
+            $finish;
+         end
+      end
+
+      r_en = 0;
+
+      #(5*clk_per);
+      $display("%c[1;34m",27);
+      $display("Test completed successfully.");
+      $display("%c[0m",27);
+      $finish;
+   end
+
+   // Instantiate the Unit Under Test (UUT)
+   iob_ram_2p_be
+     #(
+       .DATA_W(`DATA_W),
+       .ADDR_W(`ADDR_W)
+       )
+   uut
+     (
+      .clk(clk),
+
+      .w_en(w_en),
+      .w_addr(w_addr),
+      .w_data(w_data),
+
+      .r_en(r_en),
+      .r_addr(r_addr),
+      .r_data(r_data)
+      );
+
+   // Clock
+   always #(clk_per/2) clk = ~clk;
+
+endmodule


### PR DESCRIPTION
This ram component allows the `w_en` signal to select which bytes to write.
This component is required by iob_ram_2p_asym when using asymetric input/output (the `ext_mem_w_en` signal from that component has multiple bits).