### PR TITLE
Removed iob-split unused msb of s_sel; Edited makehex.py;

### DIFF
--- a/hardware/iob_split/iob_split.v
+++ b/hardware/iob_split/iob_split.v
@@ -11,7 +11,7 @@ module iob_split
    (
     input                            clk,
     input                            rst,
-  
+
     //masters interface
     input [`REQ_W-1:0]               m_req,
     output reg [`RESP_W-1:0]         m_resp,
@@ -20,13 +20,14 @@ module iob_split
     output reg [N_SLAVES*`REQ_W-1:0] s_req,
     input [N_SLAVES*`RESP_W-1:0]     s_resp
     );
-   
+
    localparam  Nb=$clog2(N_SLAVES)+($clog2(N_SLAVES)==0);
-   
+
 
    //slave select word
-   wire [Nb:0]                      s_sel = m_req[P_SLAVES+1 -:Nb+1] & ({(Nb+1){1'b1}}>>1);
-   
+   wire [Nb-1:0] s_sel;
+   assign s_sel = m_req[P_SLAVES -:Nb];
+
    //route master request to selected slave
    integer                           i;
    always @* begin
@@ -41,20 +42,20 @@ module iob_split
        else
          s_req[`req(i)] = {(`REQ_W){1'b0}};
    end
-   
+
    //
    //route response from previously selected slave to master
    //
 
    //register the slave selection
-   reg [Nb:0]                       s_sel_reg;
+   reg [Nb-1:0]                       s_sel_reg;
    always @( posedge clk, posedge rst ) begin
       if( rst )
         s_sel_reg <= {Nb{1'b0}};
       else
-        s_sel_reg <= s_sel;          
+        s_sel_reg <= s_sel;
    end
-   
+
    //route
    integer                           j;
    always @* begin
@@ -63,5 +64,5 @@ module iob_split
         if( j == s_sel_reg )
           m_resp = s_resp[`resp(j)];
    end
-   
+
 endmodule

--- a/software/python/makehex.py
+++ b/software/python/makehex.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 from sys import argv
 import sys

--- a/software/python/makehex.py
+++ b/software/python/makehex.py
@@ -1,20 +1,53 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 
 from sys import argv
+import sys
 
-binfile = argv[1]
-mem_size = 2**(int(argv[2]))
+def print_usage():
+    usage_str = """
+                Usage: ./makehex.py 1st_File 2nd_File 2nd_File_addr ... Firmware_Size > output
+                The first file is the main file and its address is 0.
+                """
+    print(usage_str, file=sys.stderr)
 
-with open(binfile, "rb") as f:
-    bindata = f.read()
+def main():
+    assert len(argv) % 2 == 1
+    nFiles = int((len(argv)-3)/2)+1
+    mem_size = 2**(int(argv[-1]))
+    binfile = [argv[1]]
+    binaddr = [0]
+    bindata = []
+    aux = []
 
-assert len(bindata) <= mem_size
-assert len(bindata) % 4 == 0
+    for i in range(nFiles-1):
+        binfile.append(argv[(i+1)*2])
+        binaddr.append(int(argv[(i+1)*2+1], 16))
 
-for i in range(int(mem_size/4)):
-    if i < (len(bindata)/4):
-        w = bindata
-        print('%02x%02x%02x%02x' % (w[4*i+3], w[4*i+2], w[4*i+1], w[4*i+0]))
-    else:
-        print("00000000")
+    for i in range(nFiles):
+        with open(binfile[i], "rb") as f:
+            bindata.append(f.read())
+        aux.append(0)
 
+    for i in range(nFiles):
+        while(len(bindata[i]) % 4 != 0):
+            bindata[i] += b'0'
+
+    for i in range(nFiles):
+        assert binaddr[i]+len(bindata[i]) <= mem_size
+        assert (binaddr[i]+len(bindata[i])) % 4 == 0
+
+    valid = False
+    for i in range(int(mem_size/4)):
+        for j in range(nFiles):
+            # If using the external memory than adress is 0x80..., but the place in the hex file sould not take into consideration the msb.
+            aux[j] = i - int((binaddr[j] & ~(1<<31))/4)
+            if (aux[j] < (len(bindata[j])/4)) and (aux[j] >= 0):
+                w = bindata[j]
+                print('%02x%02x%02x%02x' % (w[4*aux[j]+3], w[4*aux[j]+2], w[4*aux[j]+1], w[4*aux[j]+0]))
+                valid = True
+                break;
+        if not valid:
+            print("00000000")
+        valid = False
+
+main()


### PR DESCRIPTION
Added support for multiple files to makehex.py;
Usage: ./makehex.py 1st_File 2nd_File 2nd_File_addr ... Firmware_Size > output
The first file is the main file and its address is 0.

This PR was tested with the current iob-soc, and it works fine;