### PR TITLE
fix(verilog2tex): check all sources for IO table

### DIFF
--- a/build/sw/python/verilog2tex.py
+++ b/build/sw/python/verilog2tex.py
@@ -349,7 +349,7 @@ def main () :
     block_parse([*topv_lines, *v])
 
     #PARSE INTERFACE SIGNALS
-    io_parse ([*topv_lines, *vh], params, defines)
+    io_parse ([*topv_lines, *v, *vh], params, defines)
 
     #PARSE SOFTWARE ACCESSIBLE REGISTERS
     if conf != []:


### PR DESCRIPTION
- check TOP_MODULE and all other VSRCS for START_IO_TABLE and generate
  interface tables accordingly
- for example iob-cache has two top modules that need parsing to
  generate all interface signal tables