### PR TITLE
fix(setup): copy mk segments from CORE sim

### DIFF
--- a/setup.mk
+++ b/setup.mk
@@ -54,6 +54,9 @@ ifneq ($(wildcard $(CORE_DIR)/mkregs.conf),)
 endif
 ifneq ($(SETUP_SIM),0)
 	cp -u $(CORE_SIM_DIR)/*.expected $(BUILD_SIM_DIR)
+ifneq ($(wildcard $(CORE_SIM_DIR)/*.mk),)
+	cp -u $(CORE_SIM_DIR)/*.mk $(BUILD_SIM_DIR)
+endif
 	cp -u $(CORE_SIM_DIR)/*_tb.* $(BUILD_VSRC_DIR)
 endif
 ifneq ($(SETUP_FPGA),0)


### PR DESCRIPTION
- copy core makefile segments from CORE_DIR/harwdare/simulation/
  directory into `BUILD_DIR_SIM`
- these files are used for simulation, namely `simulation.mk`