### PR TITLE
fix(setup): rename sim_setup.mk

### DIFF
--- a/setup.mk
+++ b/setup.mk
@@ -36,7 +36,7 @@ $(BUILD_DIR):
 
 # import core hardware and simulation files
 include $(CORE_DIR)/hardware/hardware.mk
-include $(CORE_DIR)/hardware/simulation/simulation.mk
+include $(CORE_DIR)/hardware/simulation/sim_setup.mk
 
 # copy core version header file
 VHDR+=$(BUILD_VSRC_DIR)/$(NAME)_version.vh
@@ -54,8 +54,8 @@ ifneq ($(wildcard $(CORE_DIR)/mkregs.conf),)
 endif
 ifneq ($(SETUP_SIM),0)
 	cp -u $(CORE_SIM_DIR)/*.expected $(BUILD_SIM_DIR)
-ifneq ($(wildcard $(CORE_SIM_DIR)/*.mk),)
-	cp -u $(CORE_SIM_DIR)/*.mk $(BUILD_SIM_DIR)
+ifneq ($(wildcard $(CORE_SIM_DIR)/simulation.mk),)
+	cp -u $(CORE_SIM_DIR)/simulation.mk $(BUILD_SIM_DIR)
 endif
 	cp -u $(CORE_SIM_DIR)/*_tb.* $(BUILD_VSRC_DIR)
 endif


### PR DESCRIPTION
- use `sim_setup.mk` makefile fragment to check for specific VSRC and
  VHDR files related to core simulation
- copy core's `simulation.mk` makefile fragment if exists. Only this
  makefile fragment is imported in `BUILD_SIM_DIR/Makefile`