### PR TITLE
Optional usage of `config_setup.mk` and `config.mk`

### DIFF
--- a/build/hw/sim/Makefile
+++ b/build/hw/sim/Makefile
@@ -3,7 +3,11 @@
 
 SHELL:=/bin/bash
 
-include ../../info.mk
+CORE_DIR:=../..
+include $(CORE_DIR)/info.mk
+ifneq ($(wildcard $(CORE_DIR)/config.mk),)
+include $(CORE_DIR)/config.mk
+endif
 
 REMOTE_BUILD_DIR=sandbox/$(NAME)_$(VERSION_STR)
 

--- a/build/sw/emb/Makefile
+++ b/build/sw/emb/Makefile
@@ -1,4 +1,8 @@
-include ../../info.mk
+CORE_DIR:=../..
+include $(CORE_DIR)/info.mk
+ifneq ($(wildcard $(CORE_DIR)/config.mk),)
+include $(CORE_DIR)/config.mk
+endif
 
 TEMPLATE_LDS=../src/template.lds
 

--- a/build/sw/pc/Makefile
+++ b/build/sw/pc/Makefile
@@ -1,4 +1,8 @@
-include ../../info.mk
+CORE_DIR:=../..
+include $(CORE_DIR)/info.mk
+ifneq ($(wildcard $(CORE_DIR)/config.mk),)
+include $(CORE_DIR)/config.mk
+endif
 
 # compiler flags
 CFLAGS=-Os -std=gnu99 -Wl,--strip-debug

--- a/setup.mk
+++ b/setup.mk
@@ -1,6 +1,9 @@
 
 # core info
 include $(CORE_DIR)/info.mk
+ifneq ($(wildcard $(CORE_DIR)/config_setup.mk),)
+include $(CORE_DIR)/config_setup.mk
+endif
 
 # enable all flows in setup by default
 SETUP_SW ?=1
@@ -58,6 +61,9 @@ $(BUILD_VSRC_DIR)/$(NAME)_version.vh: $(NAME)_version.vh
 setup: $(BUILD_DIR) $(VHDR) $(VSRC) $(HDR) $(SRC)
 	echo "VERSION_STR=$(VERSION_STR)" > $(BUILD_DIR)/version.mk
 	cp -u $(CORE_DIR)/info.mk $(BUILD_DIR)
+ifneq ($(wildcard $(CORE_DIR)/config.mk),)
+	cp -u $(CORE_DIR)/config.mk $(BUILD_DIR)
+endif
 ifneq ($(wildcard $(CORE_DIR)/mkregs.conf),)
 	cp -u $(CORE_DIR)/mkregs.conf $(BUILD_TSRC_DIR)
 endif


### PR DESCRIPTION
- Add option to use `config_setup.mk` makefile fragment with custom CORE targets and variables during `setup`
- Add option to use `config.mk` makefile fragment with custom CORE targets and variables for BUILD_DIR makefiles