### PR TITLE
Remove PC macro, add `NOCLEAN` variable for exceptions

### DIFF
--- a/build/hw/sim/Makefile
+++ b/build/hw/sim/Makefile
@@ -69,7 +69,7 @@ ifeq ($(VCD),1)
 endif
 
 clean:
-	@find . -type f -not \( -name "Makefile" -o -name "*.mk" -o -name "test.*" -o -name "*_tb.*" \) -delete
+	@find . -type f -not \( -name "Makefile" -o -name "*.mk" -o -name "test.*" -o -name "*_tb.*" $(NOCLEAN) \) -delete
 ifneq ($(SIM_SERVER),)
 	ssh $(SIM_SSH_FLAGS) $(SIM_USER)@$(SIM_SERVER) 'if [ -f $(REMOTE_BUILD_DIR)/fpga/Makefile ]; then make -C $(REMOTE_BUILD_DIR)/hw/sim clean; fi'
 endif

--- a/build/sw/pc/Makefile
+++ b/build/sw/pc/Makefile
@@ -9,8 +9,6 @@ CFLAGS=-Os -std=gnu99 -Wl,--strip-debug
 
 CONSOLE_CMD=../python/console -L
 
-DEFINE+=PC
-
 INCLUDE=-I.
 INCLUDE+=-I../src
 

--- a/hardware/iob_edge_detect/hardware.mk
+++ b/hardware/iob_edge_detect/hardware.mk
@@ -1,5 +1,4 @@
-
-ifneq (iob_edge_detect,$(filter iob_edge_detect, $(HW_MODULES)),)
+ifeq ($(filter iob_edge_detect, $(HW_MODULES)),)
 
 # Add to modules list
 HW_MODULES+=iob_edge_detect

--- a/hardware/iob_modcnt/hardware.mk
+++ b/hardware/iob_modcnt/hardware.mk
@@ -1,5 +1,4 @@
-
-ifneq (iob_modcnt,$(filter iob_modcnt, $(HW_MODULES)),)
+ifeq ($(filter iob_modcnt, $(HW_MODULES)),)
 
 # Add to modules list
 HW_MODULES+=iob_modcnt

--- a/hardware/iob_reset_sync/hardware.mk
+++ b/hardware/iob_reset_sync/hardware.mk
@@ -1,5 +1,4 @@
-
-ifneq (iob_reset_sync,$(filter iob_reset_sync, $(HW_MODULES)),)
+ifeq ($(filter iob_reset_sync, $(HW_MODULES)),)
 
 # Add to modules list
 HW_MODULES+=iob_reset_sync

--- a/hardware/iob_reset_sync/iob_reset_sync.v
+++ b/hardware/iob_reset_sync/iob_reset_sync.v
@@ -1,20 +1,20 @@
 `timescale 1ns / 1ps
 
-`include "iob_lib.vh"
-
 module iob_reset_sync
   (
-   `IOB_INPUT(clk, 1),
-   `IOB_INPUT(rst, 1),
-   `IOB_OUTPUT(rst_out, 1)
+   input  clk,
+   input  rst,
+   output rst_out
    );
 
    reg [1:0] sync_reg;
-   always @(posedge clk, posedge rst)
-     if (rst)
-       sync_reg <= 2'b11;
-     else
-       sync_reg <= {sync_reg[0], 1'b0};
+   always @(posedge clk, posedge rst) begin
+      if (rst) begin
+         sync_reg <= 2'b11;
+      end else begin
+         sync_reg <= {sync_reg[0], 1'b0};
+      end
+   end
 
    assign rst_out = sync_reg[1];
 


### PR DESCRIPTION
- PC macro/define is not always necessary
  - define PC in `pc-emul.mk` if needed
- add `NOCLEAN` variable to customize simulation clean target
- this allows the usage of `BUILD_LIB/hw/sim` directory to place
  simulation specific sources without being deleted