### PR TITLE
fix(build): remove config_setup from build make

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -1,17 +1,12 @@
 SHELL:=/bin/bash
 export
 
-include config_setup.mk
-
-
 # 
 # EMBEDDED SOFTWARE
 #
 EMB_DIR=sw/emb
-ifeq ($(SETUP_SW),1)
 fw-build:
 	make -C $(EMB_DIR) build-all
-endif
 
 fw-clean:
 	make -C $(EMB_DIR) clean-all
@@ -20,7 +15,6 @@ fw-clean:
 # PC EMUL
 #
 PC_DIR=sw/pc
-ifeq ($(SETUP_SW),1)
 pc-emul-build: fw-build
 	make -C $(PC_DIR) build
 
@@ -29,7 +23,6 @@ pc-emul-run:
 
 pc-emul-test:
 	make -C $(PC_DIR) test
-endif
 
 pc-emul-clean:
 	make -C $(PC_DIR) clean
@@ -39,7 +32,6 @@ pc-emul-clean:
 # SIMULATE
 #
 SIM_DIR=hw/sim
-ifeq ($(SETUP_SIM),1)
 sim-build: 
 	make -C $(SIM_DIR) build
 
@@ -51,7 +43,6 @@ sim-test:
 
 sim-debug: 
 	make -C $(SIM_DIR) debug
-endif
 
 sim-clean: 
 	make -C $(SIM_DIR) clean
@@ -61,7 +52,6 @@ sim-clean:
 # FPGA
 #
 FPGA_DIR=hw/fpga
-ifeq ($(SETUP_FPGA),1)
 fpga-build: 
 	make -C $(FPGA_DIR) build
 
@@ -73,7 +63,6 @@ fpga-test:
 
 fpga-debug: 
 	make -C $(FPGA_DIR) debug
-endif
 
 fpga-clean: 
 	make -C $(FPGA_DIR) clean
@@ -83,7 +72,6 @@ fpga-clean:
 # DOCUMENT
 #
 DOC_DIR=doc
-ifeq ($(SETUP_DOC),1)
 doc-build: 
 	make -C $(DOC_DIR) build
 
@@ -92,7 +80,6 @@ doc-test:
 
 doc-debug: 
 	make -C $(DOC_DIR) debug
-endif
 
 doc-clean: 
 	make -C $(DOC_DIR) clean
@@ -100,15 +87,9 @@ doc-clean:
 #
 # TEST
 #
-ifeq ($(SETUP_SIM),1)
 TEST_TYPE_LIST=sim-test
-endif
-ifeq ($(SETUP_FPGA),1)
 TEST_TYPE_LIST=fpga-test
-endif
-ifeq ($(SETUP_DOC),1)
 TEST_TYPE_LIST=doc-test
-endif
 
 test: $(TEST_TYPE_LIST)
 


### PR DESCRIPTION
- remove config_setup from build makefile, use config_setup.mk only for
  setup step of workflow
- add BUILD_DIR/sw/bsrc/ directory (needed for soc)