### PR TITLE
fix(mem): rename `IS_CYCLONEV` macro

### DIFF
--- a/hardware/ram/iob_ram_2p_be/iob_ram_2p_be.v
+++ b/hardware/ram/iob_ram_2p_be/iob_ram_2p_be.v
@@ -25,7 +25,7 @@ module iob_ram_2p_be
    localparam COL_W = 8;
    localparam NUM_COL = DATA_W/COL_W;
 
-`ifdef IS_CYCLONEV
+`ifdef IOB_MEM_NO_READ_ON_WRITE
    localparam file_suffix = {"7","6","5","4","3","2","1","0"};
 
    genvar                    i;
@@ -51,7 +51,7 @@ module iob_ram_2p_be
             );
       end
    endgenerate
-`else // !IS_CYCLONEV
+`else // !IOB_MEM_NO_READ_ON_WRITE
    //this allows ISE 14.7 to work; do not remove
    localparam mem_init_file_int = HEXFILE;
 

--- a/hardware/ram/iob_ram_dp/iob_ram_dp.v
+++ b/hardware/ram/iob_ram_dp/iob_ram_dp.v
@@ -40,7 +40,7 @@ module iob_ram_dp
       if (enA)
         if (weA)
 	        ram[addrA] <= dinA;
-      `ifdef IS_CYCLONEV
+      `ifdef IOB_MEM_NO_READ_ON_WRITE
         else
       `endif
       doutA <= ram[addrA];
@@ -50,7 +50,7 @@ module iob_ram_dp
       if (enB)
         if (weB)
 	        ram[addrB] <= dinB;
-      `ifdef IS_CYCLONEV
+      `ifdef IOB_MEM_NO_READ_ON_WRITE
         else
       `endif
 	    doutB <= ram[addrB];

--- a/hardware/ram/iob_ram_dp_be/iob_ram_dp_be.v
+++ b/hardware/ram/iob_ram_dp_be/iob_ram_dp_be.v
@@ -30,7 +30,7 @@ module iob_ram_dp_be
    localparam COL_W = 8;
    localparam NUM_COL = DATA_W/COL_W;
 
-`ifdef IS_CYCLONEV
+`ifdef IOB_MEM_NO_READ_ON_WRITE
    localparam file_suffix = {"7","6","5","4","3","2","1","0"};
 
    genvar                    i;
@@ -61,7 +61,7 @@ module iob_ram_dp_be
             );
       end
    endgenerate
-`else // !IS_CYCLONEV
+`else // !IOB_MEM_NO_READ_ON_WRITE
    // this allow ISE 14.7 to work; do not remove
    localparam mem_init_file_int = {HEXFILE, ".hex"};
 

--- a/hardware/ram/iob_ram_sp_be/iob_ram_sp_be.v
+++ b/hardware/ram/iob_ram_sp_be/iob_ram_sp_be.v
@@ -22,7 +22,7 @@ module iob_ram_sp_be
    localparam NUM_COL = DATA_W/COL_W;
 
    // Operation
-`ifdef IS_CYCLONEV
+`ifdef IOB_MEM_NO_READ_ON_WRITE
    localparam file_suffix = {"7","6","5","4","3","2","1","0"};
 
    genvar                     i;
@@ -47,7 +47,7 @@ module iob_ram_sp_be
             );
       end
    endgenerate
-`else // !IS_CYCLONEV
+`else // !IOB_MEM_NO_READ_ON_WRITE
    // this allows ISE 14.7 to work; do not remove
    localparam mem_init_file_int = {HEXFILE, ".hex"};
 

--- a/hardware/ram/iob_ram_tdp/iob_ram_tdp.v
+++ b/hardware/ram/iob_ram_tdp/iob_ram_tdp.v
@@ -40,7 +40,7 @@ module iob_ram_tdp
       if (enA)
         if (weA)
 	        ram[addrA] <= dinA;
-      `ifdef IS_CYCLONEV
+      `ifdef IOB_MEM_NO_READ_ON_WRITE
         else
       `endif
       doutA <= ram[addrA];
@@ -51,7 +51,7 @@ module iob_ram_tdp
       if (enB)
         if (weB)
 	        ram[addrB] <= dinB;
-      `ifdef IS_CYCLONEV
+      `ifdef IOB_MEM_NO_READ_ON_WRITE
         else
       `endif
 	    doutB <= ram[addrB];

--- a/hardware/ram/iob_ram_tdp_be/iob_ram_tdp_be.v
+++ b/hardware/ram/iob_ram_tdp_be/iob_ram_tdp_be.v
@@ -30,7 +30,7 @@ module iob_ram_tdp_be
    localparam COL_W = 8;
    localparam NUM_COL = DATA_W/COL_W;
 
-`ifdef IS_CYCLONEV
+`ifdef IOB_MEM_NO_READ_ON_WRITE
    localparam file_suffix = {"7","6","5","4","3","2","1","0"};
 
    genvar                    i;
@@ -61,7 +61,7 @@ module iob_ram_tdp_be
             );
       end
    endgenerate
-`else // !IS_CYCLONEV
+`else // !IOB_MEM_NO_READ_ON_WRITE
    // this allow ISE 14.7 to work; do not remove
    localparam mem_init_file_int = {HEXFILE, ".hex"};
 


### PR DESCRIPTION
- rename `IS_CYCLONEV` macro for iob memories to
  `IOB_MEM_NO_READ_ON_WRITE`