### PR TITLE
fix(doc): correct path to figures dir

### DIFF
--- a/document/tsrc/pb.cls
+++ b/document/tsrc/pb.cls
@@ -45,7 +45,7 @@
 }
 
 \pagestyle{fancy}
-\graphicspath{{../figures/} {./}}
+\graphicspath{{./figures/} {./}}
 
 
 \renewcommand{\headrulewidth}{.4pt}


### PR DESCRIPTION
- pb.cls was adding ../figures to graphicspath, now should be ./figures, like in ug.cls