### PR TITLE
Get peripheral directories by parsing config_setup.mk

### DIFF
--- a/scripts/createSystem.py
+++ b/scripts/createSystem.py
@@ -22,12 +22,11 @@ def insert_header_files(template_contents, root_dir):
             template_contents.insert(header_index, f'`include "{file}"\n')
 
 
-def create_systemv(root_dir, directories_str, peripherals_str, file_path):
+def create_systemv(root_dir, peripherals_str, file_path):
     # Get peripherals, directories and signals
     instances_amount, instances_parameters = get_peripherals(peripherals_str)
-    submodule_directories = get_submodule_directories(directories_str)
-    print("BLA", submodule_directories, directories_str)
-    peripheral_signals, peripheral_parameters = get_peripherals_signals(instances_amount,submodule_directories)
+    submodule_directories = get_submodule_directories(root_dir)
+    peripheral_signals, peripheral_parameters = get_peripherals_signals(root_dir, instances_amount,submodule_directories)
     print(f'peripheral_signals: {peripheral_signals}')
     print(f'peripheral_parameters: {peripheral_parameters}')
 
@@ -95,9 +94,7 @@ def create_systemv(root_dir, directories_str, peripherals_str, file_path):
 
 if __name__ == "__main__":
     # Parse arguments
-    if len(sys.argv)<5:
-        print("Usage: {} <root_dir> <directories_defined_in_config.mk> <peripherals> <path of file to be created>\n".format(sys.argv[0]))
+    if len(sys.argv)<4:
+        print("Usage: {} <root_dir> <peripherals> <path of file to be created>\n".format(sys.argv[0]))
         exit(-1)
-    root_dir=sys.argv[1]
-    submodule_utils.root_dir = root_dir
-    create_systemv(root_dir, sys.argv[2], sys.argv[3], sys.argv[4]) 
+    create_systemv(sys.argv[1], sys.argv[2], sys.argv[3]) 

--- a/scripts/createTestbench.py
+++ b/scripts/createTestbench.py
@@ -8,10 +8,10 @@ import submodule_utils
 from submodule_utils import *
 import createSystem
 
-def create_system_testbench(root_dir, directories_str, peripherals_str, file_path):
+def create_system_testbench(root_dir, peripherals_str, file_path):
     # Get peripherals, directories and signals
     instances_amount, _ = get_peripherals(peripherals_str)
-    submodule_directories = get_submodule_directories(directories_str)
+    submodule_directories = get_submodule_directories(root_dir)
 
     # Read template file
     template_file = open(root_dir+"/hardware/simulation/system_tb.vt", "r")
@@ -29,9 +29,7 @@ def create_system_testbench(root_dir, directories_str, peripherals_str, file_pat
 
 if __name__ == "__main__":
     # Parse arguments
-    if len(sys.argv)<5:
-        print("Usage: {} <root_dir> <directories_defined_in_config.mk> <peripherals> <path of file to be created>\n".format(sys.argv[0]))
+    if len(sys.argv)<4:
+        print("Usage: {} <root_dir> <peripherals> <path of file to be created>\n".format(sys.argv[0]))
         exit(-1)
-    root_dir=sys.argv[1]
-    submodule_utils.root_dir = root_dir
-    create_system_testbench(root_dir, sys.argv[2], sys.argv[3], sys.argv[4]) 
+    create_system_testbench(sys.argv[1], sys.argv[2], sys.argv[3]) 

--- a/scripts/createTopSystem.py
+++ b/scripts/createTopSystem.py
@@ -8,11 +8,11 @@ import submodule_utils
 from submodule_utils import *
 import createSystem
 
-def create_top_system(root_dir, directories_str, peripherals_str, file_path):
+def create_top_system(root_dir, peripherals_str, file_path):
     # Get peripherals, directories and signals
     instances_amount, instances_parameters = get_peripherals(peripherals_str)
-    submodule_directories = get_submodule_directories(directories_str)
-    peripheral_signals, peripheral_parameters = get_peripherals_signals(instances_amount,submodule_directories)
+    submodule_directories = get_submodule_directories(root_dir)
+    peripheral_signals, peripheral_parameters = get_peripherals_signals(root_dir, instances_amount,submodule_directories)
 
     # Read template file
     template_file = open(root_dir+"/hardware/simulation/system_top.vt", "r")
@@ -48,9 +48,7 @@ def create_top_system(root_dir, directories_str, peripherals_str, file_path):
 
 if __name__ == "__main__":
     # Parse arguments
-    if len(sys.argv)<5:
-        print("Usage: {} <root_dir> <directories_defined_in_config.mk> <peripherals> <path of file to be created>\n".format(sys.argv[0]))
+    if len(sys.argv)<4:
+        print("Usage: {} <root_dir> <peripherals> <path of file to be created>\n".format(sys.argv[0]))
         exit(-1)
-    root_dir=sys.argv[1]
-    submodule_utils.root_dir = root_dir
-    create_top_system(root_dir, sys.argv[2], sys.argv[3], sys.argv[4]) 
+    create_top_system(sys.argv[1], sys.argv[2], sys.argv[3]) 


### PR DESCRIPTION
- get_submodule_directories() in `submodule_utils.py` now parses the `config_setup.mk` file located on the root_dir, finding every variable defined ending with "_DIR".
- Removed directories_str parameter, as it is no longer needed.
- Remove root_dir global variable from submodule_utils.py; Use local root_dir variables instead.