### PR TITLE
PC-Emul support

### DIFF
--- a/build.mk
+++ b/build.mk
@@ -16,7 +16,7 @@ endif
 #
 # PC EMUL
 #
-PC_DIR=software/pc
+PC_DIR=software/pc-emul
 ifneq ($(wildcard $(PC_DIR)),)
 pc-emul-build: fw-build
 	make -C $(PC_DIR) build

--- a/setup.mk
+++ b/setup.mk
@@ -20,11 +20,12 @@ VERSION_STR := $(shell $(PYTHON_DIR)/version.py -i .)
 BUILD_DIR := ../$(NAME)_$(VERSION_STR)
 
 BUILD_VSRC_DIR = $(BUILD_DIR)/hardware/src
+BUILD_PC_DIR = $(BUILD_DIR)/software/pc-emul
 BUILD_SIM_DIR = $(BUILD_DIR)/hardware/simulation
 BUILD_FPGA_DIR = $(BUILD_DIR)/hardware/fpga
 
 BUILD_ESRC_DIR = $(BUILD_DIR)/software/esrc
-BUILD_PSRC_DIR = $(BUILD_DIR)/software/esrc
+BUILD_PSRC_DIR = $(BUILD_DIR)/software/psrc
 BUILD_DOC_DIR = $(BUILD_DIR)/document
 BUILD_FIG_DIR = $(BUILD_DOC_DIR)/figures
 BUILD_TSRC_DIR = $(BUILD_DOC_DIR)/tsrc
@@ -72,6 +73,12 @@ $(BUILD_VSRC_DIR)/%: $(1)/hardware/src/%
 	cp $< $@
 endef
 
+#copy pc-emul files from LIB
+ifneq ($(wildcard software/pc-emul),)
+SRC+=$(patsubst $(LIB_DIR)/software/pc-emul/%, $(BUILD_PC_DIR)/%, $(wildcard $(LIB_DIR)/software/pc-emul/*))
+$(BUILD_PC_DIR)/%: $(LIB_DIR)/software/pc-emul/%
+	cp $< $@
+endif
 
 
 #simulation

--- a/setup.mk
+++ b/setup.mk
@@ -212,7 +212,7 @@ endif
 
 
 clean:
-	@rm -rf $(BUILD_DIR) *.tex *.v *.vh
+	@rm -rf $(BUILD_DIR) *.tex *.v *.vh *.h
 	@rm -rf scripts/__pycache__
 
 debug: $(BUILD_DIR) $(SRC) v2tex

--- a/software/pc-emul/Makefile
+++ b/software/pc-emul/Makefile
@@ -8,16 +8,16 @@ include ../../info.mk
 # compiler flags
 CFLAGS=-Os -std=gnu99 -Wl,--strip-debug
 
-CONSOLE_CMD=../python/console -L
+CONSOLE_CMD=../../scripts/console -L
 
 INCLUDE=-I.
 INCLUDE+=-I../src
 
 HDR=$(wildcard *.h)
-HDR+=$(wildcard ../src/*.h)
+HDR+=$(wildcard ../psrc/*.h)
 
 SRC=$(wildcard *.c)
-SRC+=$(wildcard ../src/*.c)
+SRC+=$(wildcard ../psrc/*.c)
 
 # include local pc-emul segment
 # all previously defined variables can be overwritten in this file


### PR DESCRIPTION
- Update pc-emul support, tested for iob-soc
- set `software/pc-emul` as directory for pc-emul BUILD_DIR
- fix/add some BUILD_<PATH>_DIR variables related to pc-emul
- automate LIB/software/pc-emul file copy during setup (if `CORE/software/pc-emul` exists)
- update pc-emul Makefile
- clean generated C header source files