### PR TITLE
fix(sim): option to change simulation top

### DIFF
--- a/hardware/simulation/verilator.mk
+++ b/hardware/simulation/verilator.mk
@@ -1,4 +1,8 @@
-VFLAGS+=--cc --exe -I. -I../src --top-module $(NAME)
+# VTOP = NAME by default, to change overwrite in 
+# CORE/hardware/simulation/simulation.mk
+VTOP?=$(NAME)
+
+VFLAGS+=--cc --exe -I. -I../src --top-module $(VTOP)
 VFLAGS+=-Wno-lint
 
 ifeq ($(VCD),1)
@@ -10,9 +14,9 @@ SIM_USER=$(VSIM_USER)
 
 comp: $(VHDR) $(VSRC)
 	verilator $(VFLAGS) $(VSRC) $(NAME)_tb.cpp	
-	cd ./obj_dir && make -f V$(NAME).mk
+	cd ./obj_dir && make -f V$(VTOP).mk
 
 exec:
-	./obj_dir/V$(NAME) | tee -a test.log
+	./obj_dir/V$(VTOP) | tee -a test.log
 
 .PHONY: comp exec


### PR DESCRIPTION
- add option to change simulation top for verilator
- set `VTOP=$(NAME)` by default (current behaviour)
- allow for overwrittes by `CORE/hardware/simulation/simulation.mk` - for example this is needed for IObundle/iob-cache that has a top `iob_cache_sim_wrapper` for simulation