### PR TITLE
Improvements to embedded software workflow, mkregs help message

### DIFF
--- a/build.mk
+++ b/build.mk
@@ -7,9 +7,9 @@ include info.mk
 # EMBEDDED SOFTWARE
 #
 ifneq ($(filter emb, $(FLOWS)),)
-EMB_DIR=software/emb
+EMB_DIR=software/embedded
 fw-build:
-	make -C $(EMB_DIR) build-all
+	make -C $(EMB_DIR) fw-build
 
 fw-clean:
 	make -C $(EMB_DIR) clean-all

--- a/hardware/fpga/Makefile
+++ b/hardware/fpga/Makefile
@@ -6,6 +6,10 @@ SHELL:=/bin/bash
 # include core basic info
 include ../../info.mk
 
+ifneq ($(wildcard ../../console.mk),)
+include ../../console.mk
+endif
+
 REMOTE_BUILD_DIR=sandbox/$(NAME)
 REMOTE_FPGA_DIR=$(REMOTE_BUILD_DIR)/hardware/fpga
 

--- a/scripts/mkregs.py
+++ b/scripts/mkregs.py
@@ -85,9 +85,9 @@ def print_help():
     Example mkregs.conf file:
     //START_SWREG_TABLE example_core
     IOB_SWREG_W(CORE_RUN, 1, 0, 2, 0) //Run write register at address 2
-    IOB_SWMEM_W(CORE_WR_BUF, 2, 0, 4, 12) //2^12 x 16 bit write mem at addr 4
+    IOB_SWREG_W(CORE_WR_BUF, 2, 0, 4, 12) //2^12 x 16 bit write mem at addr 4
     IOB_SWREG_R(CORE_DONE, 1, 0, 1, 0) //Done read register at address 1
-    IOB_SWMEM_R(CORE_RD_BUF, 4, 0, 4, 10) //2^10 x 4 bit read mem at addr 4
+    IOB_SWREG_R(CORE_RD_BUF, 4, 0, 4, 10) //2^10 x 4 bit read mem at addr 4
     """
 
     print(help_str)

--- a/setup.mk
+++ b/setup.mk
@@ -20,6 +20,7 @@ VERSION_STR := $(shell $(PYTHON_DIR)/version.py -i .)
 BUILD_DIR := ../$(NAME)_$(VERSION_STR)
 
 BUILD_VSRC_DIR = $(BUILD_DIR)/hardware/src
+BUILD_EMB_DIR = $(BUILD_DIR)/software/embedded
 BUILD_PC_DIR = $(BUILD_DIR)/software/pc-emul
 BUILD_SIM_DIR = $(BUILD_DIR)/hardware/simulation
 BUILD_FPGA_DIR = $(BUILD_DIR)/hardware/fpga
@@ -131,6 +132,13 @@ SRC+=$(patsubst $(LIB_DIR)/software/src/%, $(BUILD_ESRC_DIR)/%, $(wildcard $(LIB
 $(BUILD_ESRC_DIR)/%: $(LIB_DIR)/software/src/%
 	cp $< $@
 
+#copy embedded files from LIB
+ifneq ($(wildcard software/embedded),)
+SRC+=$(patsubst $(LIB_DIR)/software/embedded/%, $(BUILD_EMB_DIR)/%, $(wildcard $(LIB_DIR)/software/embedded/*))
+$(BUILD_EMB_DIR)/%: $(LIB_DIR)/software/embedded/%
+	cp $< $@
+endif
+
 #copy pc-emul files from LIB
 ifneq ($(wildcard software/pc-emul),)
 SRC+=$(patsubst $(LIB_DIR)/software/pc-emul/%, $(BUILD_PC_DIR)/%, $(wildcard $(LIB_DIR)/software/pc-emul/*))
@@ -186,7 +194,7 @@ $(BUILD_DOC_DIR)/Makefile: $(LIB_DIR)/document/Makefile
 #make tex files from verilog sources
 v2tex: $(SRC)
 ifeq ($(wildcard *.tex),)
-	$(PYTHON_DIR)/verilog2tex.py $(BUILD_VSRC_DIR)/$(NAME).v $(BUILD_VSRC_DIR)/$(NAME)_conf.vh $(BUILD_VSRC_DIR)/* $(MKREGS_CONF)
+	$(PYTHON_DIR)/verilog2tex.py $(BUILD_VSRC_DIR)/$(NAME).v $(wildcard $(BUILD_VSRC_DIR)/*) $(MKREGS_CONF)
 	cp *.tex $(BUILD_TSRC_DIR)
 endif
 

--- a/software/embedded/Makefile
+++ b/software/embedded/Makefile
@@ -1,11 +1,11 @@
 # (c) 2022-Present IObundle, Lda, all rights reserved
 #
-# This makefile is used at build-time in $(BUILD_DIR)/sw/emb/Makefile
+# This makefile is used at build-time in $(BUILD_DIR)/software/embedded/Makefile
 #
 
 include ../../info.mk
 
-TEMPLATE_LDS=../src/template.lds
+TEMPLATE_LDS=../esrc/template.lds
 
 MFLAGS=$(MFLAGS_BASE)$(MFLAG_M)$(MFLAG_C)
 MFLAGS_BASE:=rv32i
@@ -26,15 +26,15 @@ BOOT_LFLAGS=$(LFLAGS) -Wl,-Map,boot.map
 FW_LFLAGS=$(LFLAGS) -Wl,-Map,firmware.map
 
 HDR=$(wildcard *.h)
-HDR+=$(wildcard ../src/*.h)
+HDR+=$(wildcard ../esrc/*.h)
 
-BOOT_SRC=../bsrc/boot.c ../bsrc/boot.S ../src/iob-uart.c  ../src/iob_uart_swreg_emb.c
+BOOT_SRC=$(wildcard ../bootloader/*)
+BOOT_SRC+=../esrc/iob-uart.c  ../esrc/iob_uart_swreg_emb.c
+BOOT_SRC+=../esrc/iob-cache.c  ../esrc/iob_cache_swreg_emb.c
 
 #FW_SRC=$(wildcard *.c)
-FW_SRC=$(wildcard ../src/*.c)
-FW_SRC+=../src/firmware.S
-# exclude bootloader sources
-FW_SRC:=$(filter-out %boot.c,$(FW_SRC))
+FW_SRC=$(wildcard ../firmware/*)
+FW_SRC+=$(wildcard ../esrc/*.c)
 
 # include local embedded segment
 # all previously defined variables can be overwritten in this file
@@ -42,26 +42,20 @@ ifneq ($(wildcard embedded.mk),)
 include embedded.mk
 endif
 
-build-all: fw-build boot-build
-
-fw-build: firmware.elf
+fw-build: boot.elf firmware.elf 
 
 firmware.elf: $(TEMPLATE_LDS) $(HDR) $(FW_SRC)
-	$(TOOLCHAIN_PREFIX)gcc -o $@ $(CFLAGS) $(FW_LFLAGS) -I. -I../src $(FW_SRC) $(LLIBS)
+	$(TOOLCHAIN_PREFIX)gcc -o $@ $(CFLAGS) $(FW_LFLAGS) -I. -I../firmware -I../esrc $(FW_SRC) $(LLIBS)
 	$(TOOLCHAIN_PREFIX)objcopy -O binary $@ firmware.bin
 
-boot-build: boot.elf
-
 boot.elf: $(TEMPLATE_LDS) $(HDR) $(BOOT_SRC)
-	$(TOOLCHAIN_PREFIX)gcc -o $@ $(CFLAGS) $(BOOT_LFLAGS) -I. -I../bsrc -I../src $(BOOT_SRC) $(LLIBS)
+	$(TOOLCHAIN_PREFIX)gcc -o $@ $(CFLAGS) $(BOOT_LFLAGS) -I. -I../bootloader -I../esrc $(BOOT_SRC) $(LLIBS)
 	$(TOOLCHAIN_PREFIX)objcopy -O binary $@ boot.bin
 
-clean-all: fw-clean boot-clean $(CLEAN_LIST)
+clean-all: fw-clean $(CLEAN_LIST)
 
 fw-clean:
 	@rm -rf firmware.bin firmware.elf firmware.map *.hex
-
-boot-clean:
 	@rm -rf boot.bin boot.elf boot.map *.hex
 
 debug:
@@ -70,6 +64,6 @@ debug:
 	@echo $(HDR)
 	@echo $(BOOT_SRC)
 
-.PHONY: build-all fw-build boot-build\
-	clean-all fw-clean boot-clean debug
+.PHONY: fw-build fw-clean\
+	clean-all debug
 

--- a/software/pc-emul/Makefile
+++ b/software/pc-emul/Makefile
@@ -5,6 +5,10 @@
 
 include ../../info.mk
 
+ifneq ($(wildcard ../../console.mk),)
+include ../../console.mk
+endif
+
 # compiler flags
 CFLAGS=-Os -std=gnu99 -Wl,--strip-debug
 


### PR DESCRIPTION
- Improvements to embedded software workflow
  - update embedded workflow to compile bootloader and firmware programs
  for embedded platform
  - import console.mk if exists, used to `kill-cnsl` target in pc-emul and
  fpga makefiles
  - embedded bootloader compilation working
- fix example in help message for `mkregs.conf`