### PR TITLE
feat(mkregs): improve address support; add example `mkregs.conf` to test

### DIFF
--- a/scripts/test_mkregs/alignedreg_mkregs.conf
+++ b/scripts/test_mkregs/alignedreg_mkregs.conf
@@ -1,0 +1,2 @@
+//START_SWREG_TABLE uart
+IOB_SWREG_R(R2, 16, 0, 1, 1, 0) // Description

--- a/scripts/test_mkregs/autoaddr_mkregs.conf
+++ b/scripts/test_mkregs/autoaddr_mkregs.conf
@@ -1,0 +1,9 @@
+//START_SWREG_TABLE uart
+IOB_SWREG_R(R1, 8, 0, -1, 0, 0) // Description
+IOB_SWREG_R(R2, 16, 0, -1, 1, 0) // Description
+IOB_SWREG_R(R3, 8, 0, -1, 0, 0) // Description
+IOB_SWREG_R(R4, 32, 0, -1, 2, 0) // Description
+IOB_SWREG_W(W1, 8, 0, -1, 0, 0) // Description
+IOB_SWREG_W(W2, 16, 0, -1, 1, 0) // Description
+IOB_SWREG_W(W3, 8, 0, -1, 0, 0) // Description
+IOB_SWREG_W(W4, 32, 0, -1, 2, 0) // Description

--- a/scripts/test_mkregs/out_of_order_addr_mkregs.conf
+++ b/scripts/test_mkregs/out_of_order_addr_mkregs.conf
@@ -1,0 +1,4 @@
+//START_SWREG_TABLE uart
+IOB_SWREG_R(R1, 8, 0, 1, 0, 0) // Description
+IOB_SWREG_R(R2, 8, 0, -1, 0, 0) // Description
+IOB_SWREG_R(R3, 8, 0, 0, 0, 0) // Description

--- a/scripts/test_mkregs/overlapped_mkregs.conf
+++ b/scripts/test_mkregs/overlapped_mkregs.conf
@@ -1,0 +1,3 @@
+//START_SWREG_TABLE uart
+IOB_SWREG_R(R1, 8, 0, 0, 1, 0) // Description
+IOB_SWREG_R(R2, 8, 0, 1, 1, 0) // Description


### PR DESCRIPTION
- mkregspy calculated new aligned addresses for registers with automatic
  addresses (ADDR<0)
- add `mkresg.conf` to test automatic addressing in
  `scripts/test_mkregs/`
- other minor improvements to mkregs.py
- support declaration of out of order registers in `mkresgs.conf`
    - `scripts/test_mkregs/out_of_order_addr_mkregs.conf`: test register
      declaration out of order
- automatic addresses start after the largest manual address
- check for aligned registers:
    - `scripts/test_mkregs/alignedreg_mkregs.conf`: test register
      alignment (expected catch register miss aligment)
- check for overlapped register ranges
    - `scripts/test_mkregs/overlapped_mkregs.conf`: test register
      range overlapping (expected to catch resgister arrays with
      overlapping)

# Note about out of order declaration in `mkregs.conf`:
Supporting declaration of registers with out of order addresses in `mkregs.conf` is important, since the documentation already uses the register declaration order to group registers into tables used in documentation.