### PR TITLE
Update mkregs.conf to use TOML configuration format

### DIFF
--- a/hardware/include/hw_setup.mk
+++ b/hardware/include/hw_setup.mk
@@ -10,7 +10,7 @@ SRC+=$(subst $(LIB_DIR)/hardware/include, $(BUILD_VSRC_DIR), $(wildcard $(LIB_DI
 $(BUILD_VSRC_DIR)/%.vh: $(LIB_DIR)/hardware/include/%.vh
 	cp $< $(BUILD_VSRC_DIR)
 
-ifneq ($(wildcard mkregs.conf),)
+ifneq ($(wildcard mkregs.toml),)
 # iob slave port for swreg files
 SRC+=$(BUILD_VSRC_DIR)/iob_s_port.vh
 $(BUILD_VSRC_DIR)/iob_s_port.vh: iob_s_port.vh

--- a/mkregs_example.toml
+++ b/mkregs_example.toml
@@ -1,0 +1,12 @@
+#Example register configuration file (used by mkregs.py script)
+
+[[latex_table1]]
+#Registers belonging to latex table 1
+REG1_NAME = {rw_type="W", nbits=1, rst_val=0, addr=-1, addr_w=0, autologic=true, description="REG1 description"} #Example write register
+REG2_NAME = {rw_type="R", nbits=1, rst_val=0, addr=-1, addr_w=0, autologic=true, description="REG2 description"} #Example read register
+REG3_NAME = {rw_type="W", nbits=8, rst_val=0, addr=-1, addr_w=0, autologic=true, description="REG3 description"} #Example 8-bit write register
+
+[[latex_table2]]
+#Registers belonging to latex table 2
+REG4_NAME = {rw_type="W", nbits=1, rst_val=0, addr=-1, addr_w=0, autologic=true, description="REG4 description"} #Example write register
+REG5_NAME = {rw_type="R", nbits=1, rst_val=0, addr=-1, addr_w=0, autologic=true, description="REG5 description"} #Example read register

--- a/setup.mk
+++ b/setup.mk
@@ -172,7 +172,7 @@ $(BUILD_TSRC_DIR)/shortHash.tex:
 
 
 #software accessible registers
-ifneq ($(wildcard mkregs.conf),)
+ifneq ($(wildcard mkregs.toml),)
 
 SRC+=$(BUILD_VSRC_DIR)/$(NAME)_swreg_gen.v $(BUILD_VSRC_DIR)/$(NAME)_swreg_def.vh $(BUILD_VSRC_DIR)/$(NAME)_swreg_inst.vh
 $(BUILD_VSRC_DIR)/$(NAME)_swreg_gen.v: $(NAME)_swreg_gen.v
@@ -181,7 +181,7 @@ $(BUILD_VSRC_DIR)/$(NAME)_swreg_gen.v: $(NAME)_swreg_gen.v
 $(BUILD_VSRC_DIR)/$(NAME)_swreg_%.vh: $(NAME)_swreg_%.vh
 	cp $< $@
 
-$(NAME)_swreg_def.vh $(NAME)_swreg_inst.vh $(NAME)_swreg_gen.v: mkregs.conf
+$(NAME)_swreg_def.vh $(NAME)_swreg_inst.vh $(NAME)_swreg_gen.v: mkregs.toml
 	$(LIB_DIR)/scripts/mkregs.py $(NAME) . HW
 
 endif
@@ -204,7 +204,7 @@ $(BUILD_DOC_DIR)/Makefile: $(LIB_DIR)/document/Makefile
 #make tex files from verilog sources
 v2tex: $(SRC)
 ifeq ($(wildcard *.tex),)
-	$(PYTHON_DIR)/verilog2tex.py $(BUILD_VSRC_DIR)/$(NAME).v $(wildcard $(BUILD_VSRC_DIR)/*) mkregs.conf
+	$(PYTHON_DIR)/verilog2tex.py $(BUILD_VSRC_DIR)/$(NAME).v $(wildcard $(BUILD_VSRC_DIR)/*) mkregs.toml
 	cp *.tex $(BUILD_TSRC_DIR)
 endif
 


### PR DESCRIPTION
Implement changes mentioned in https://github.com/IObundle/iob-lib/issues/240.
Add `mkregs_example.toml` example file in root directory of LIB.
Rename `mkregs.conf` to `mkregs.toml`.
This PR closes https://github.com/IObundle/iob-lib/issues/240.