### PR TITLE
Add feature: support Linux OS; Fix: transferred orthography;

### DIFF
--- a/software/python/console
+++ b/software/python/console
@@ -6,6 +6,7 @@ import sys
 import importlib.util
 import time
 import select
+from threading import Thread
 
 # Global variables
 ser = None
@@ -20,16 +21,16 @@ DC1 = b'\x11' # Device Control 1 <-> End of file transfers
 
 
 def tb_write(data, number_of_bytes = 1, is_file = False):
-    transfered_bytes = 0
+    transferred_bytes = 0
     write_percentage = 100
-    while(transfered_bytes < number_of_bytes):
+    while(transferred_bytes < number_of_bytes):
         while (os.path.getsize("./cnsl2soc") != 0): pass
         f = open('./cnsl2soc', "wb")
-        f.write(data[transfered_bytes].to_bytes(1, byteorder='little'))
+        f.write(data[transferred_bytes].to_bytes(1, byteorder='little'))
         f.flush()
-        transfered_bytes += 1
+        transferred_bytes += 1
         if (is_file):
-            new_percentage = int(100/number_of_bytes*transfered_bytes)
+            new_percentage = int(100/number_of_bytes*transferred_bytes)
             if(write_percentage!=new_percentage):
                 write_percentage = new_percentage
                 if (not write_percentage%10): print("%3d %c" % (write_percentage, '%'))
@@ -44,16 +45,16 @@ def tb_read_until(end = b'\x00'):
 
 def tb_read(number_of_bytes, is_file = False):
     data = b''
-    transfered_bytes = 0
+    transferred_bytes = 0
     read_percentage = 100
-    while(transfered_bytes < number_of_bytes):
+    while(transferred_bytes < number_of_bytes):
         f = open('./soc2cnsl', "rb")
         while (os.path.getsize("./soc2cnsl") == 0): pass
         byte = f.read(1)
         data += byte
-        transfered_bytes += 1
+        transferred_bytes += 1
         if (is_file):
-            new_percentage = int(100/number_of_bytes*transfered_bytes)
+            new_percentage = int(100/number_of_bytes*transferred_bytes)
             if(read_percentage!=new_percentage):
                 read_percentage = new_percentage
                 if (not read_percentage%10): print("%3d %c" % (read_percentage, '%'))
@@ -133,6 +134,17 @@ def cnsl_recvfile():
     f.close()
     print(PROGNAME, end = '')
     print(': file received'.format(file_size))
+
+def getUserInput():
+    stdin = sys.stdin
+    while(1):
+        if select.select([stdin], [], [], 0.5)[0]:
+            user_str = stdin.read(1)
+            if(user_str!=''):
+                if SerialFlag:
+                    ser.write(bytes(user_str, 'UTF-8'))
+                else:
+                    tb_write(bytes(user_str, 'UTF-8'))
 
 def endFileTransfer():
     # unset the Bytes used in IOb-SoC comunication protocol
@@ -244,6 +256,7 @@ def init_console():
 def main():
     load_fw = init_console()
     gotENQ = False
+    input_thread = Thread(target=getUserInput, args=[], daemon=True)
 
     stdin = sys.stdin
 
@@ -254,7 +267,6 @@ def main():
         # get byte from target
         if (not SerialFlag): byte = tb_read(1)
         elif (ser.isOpen()): byte = ser.read()
-
         # process command
         if (byte == ENQ):
             if (not gotENQ):
@@ -279,18 +291,13 @@ def main():
             cnsl_sendfile()
         elif (byte == DC1):
             print(PROGNAME, end = '')
-            print(': end of file transfers')
+            print(': end of file transfer')
             endFileTransfer()
+            print(PROGNAME, end = '')
+            print(': start reading user input')
+            input_thread.start()
         else:
-            print(str(byte, 'iso-8859-1'), end = '')
-            sys.stdout.flush()
-        if select.select([stdin, ], [], [], 0.0)[0]:
-            user_str = stdin.read(1)
-            if(user_str!=''):
-                if SerialFlag:
-                    ser.write(bytes(user_str, 'UTF-8'))
-                else:
-                    tb_write(bytes(user_str, 'UTF-8'))
+            print(str(byte, 'iso-8859-1'), end = '', flush=True)
 
 
 if __name__ == "__main__": main()

--- a/software/python/console
+++ b/software/python/console
@@ -5,8 +5,7 @@ import os
 import sys
 import importlib.util
 import time
-import curses.ascii
-import time
+import select
 
 # Global variables
 ser = None
@@ -194,7 +193,7 @@ def init_serial():
     ser.bytesize = serial.EIGHTBITS    # number of bits per bytes
     ser.parity = serial.PARITY_NONE    # set parity check: no parity
     ser.stopbits = serial.STOPBITS_ONE # number of stop bits
-    ser.timeout = None                 # block read
+    ser.timeout = 1                    # block read
     ser.xonxoff = False                # disable software flow control
     ser.rtscts = False                 # disable hardware (RTS/CTS) flow control
     ser.dsrdtr = False                 # disable hardware (DSR/DTR) flow control
@@ -246,6 +245,8 @@ def main():
     load_fw = init_console()
     gotENQ = False
 
+    stdin = sys.stdin
+
     # Reading the data from the serial port or FIFO files. This will be running in an infinite loop.
     while(True):
         byte = b'\x00'
@@ -283,5 +284,13 @@ def main():
         else:
             print(str(byte, 'iso-8859-1'), end = '')
             sys.stdout.flush()
+        if select.select([stdin, ], [], [], 0.0)[0]:
+            user_str = stdin.read(1)
+            if(user_str!=''):
+                if SerialFlag:
+                    ser.write(bytes(user_str, 'UTF-8'))
+                else:
+                    tb_write(bytes(user_str, 'UTF-8'))
+
 
 if __name__ == "__main__": main()

--- a/software/python/console
+++ b/software/python/console
@@ -205,7 +205,7 @@ def init_serial():
     ser.bytesize = serial.EIGHTBITS    # number of bits per bytes
     ser.parity = serial.PARITY_NONE    # set parity check: no parity
     ser.stopbits = serial.STOPBITS_ONE # number of stop bits
-    ser.timeout = 1                    # block read
+    ser.timeout = None                 # block read
     ser.xonxoff = False                # disable software flow control
     ser.rtscts = False                 # disable hardware (RTS/CTS) flow control
     ser.dsrdtr = False                 # disable hardware (DSR/DTR) flow control
@@ -257,8 +257,6 @@ def main():
     load_fw = init_console()
     gotENQ = False
     input_thread = Thread(target=getUserInput, args=[], daemon=True)
-
-    stdin = sys.stdin
 
     # Reading the data from the serial port or FIFO files. This will be running in an infinite loop.
     while(True):

--- a/software/python/noncanonical.py
+++ b/software/python/noncanonical.py
@@ -1,0 +1,20 @@
+#!/usr/bin/python
+
+# The UNIX OS Terminal has to modes of receiving user input. The first being the Canonical mode witch is the one we are normarly acostumed to.
+import sys
+import termios
+
+stdin = sys.stdin
+fd = stdin.fileno()
+
+old = termios.tcgetattr(fd)
+new = termios.tcgetattr(fd)
+new[3] &= ~termios.ECHO
+new[3] &= ~termios.ICANON
+
+termios.tcsetattr(fd, termios.TCSAFLUSH, new)
+#print('Enter a letter: ')
+#char = stdin.read(1)
+print()
+#termios.tcsetattr(fd, termios.TCSAFLUSH, old)
+#print('You entered: '+char)

--- a/software/python/noncanonical.py
+++ b/software/python/noncanonical.py
@@ -1,6 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
-# The UNIX OS Terminal has to modes of receiving user input. The first being the Canonical mode witch is the one we are normarly acostumed to.
 import sys
 import termios
 
@@ -13,8 +12,4 @@ new[3] &= ~termios.ECHO
 new[3] &= ~termios.ICANON
 
 termios.tcsetattr(fd, termios.TCSAFLUSH, new)
-#print('Enter a letter: ')
-#char = stdin.read(1)
 print()
-#termios.tcsetattr(fd, termios.TCSAFLUSH, old)
-#print('You entered: '+char)


### PR DESCRIPTION
The `getUserInput` function is launched as a thread when the console receives a `DC1` Byte;
The `noncanonical.py` file is a temporary solution to the Linux user input. It works, but it is not the best solution. The best solution would be to execute a terminal emulator in the Console program.