### PR TITLE
fix(hw): remove duplicated IOB-LIB macro

### DIFF
--- a/hardware/include/iob_lib.vh
+++ b/hardware/include/iob_lib.vh
@@ -24,7 +24,6 @@
 `define IOB_WIRE(NAME, WIDTH) wire [WIDTH-1:0] NAME;
 `define IOB_WIRE_SIGNED(NAME, WIDTH) wire signed [WIDTH-1:0] NAME;
 `define IOB_VAR(NAME, WIDTH) reg [WIDTH-1:0] NAME;
-`define IOB_VAR_INIT(NAME, WIDTH, INIT) reg [WIDTH-1:0] NAME = INIT;
 `define IOB_VAR_SIGNED(NAME, WIDTH) reg signed [WIDTH-1:0] NAME;
 `define IOB_VAR2WIRE(IN, OUT) assign OUT = IN;//convert IOB_VAR to IOB_WIRE
 //2d arrays


### PR DESCRIPTION
- remove duplicated macrom from iob_lib.vh verilog header file