### PR TITLE
Fix passing the regs table when calling HW and SW mkregs functions;

### DIFF
--- a/scripts/mkregs.py
+++ b/scripts/mkregs.py
@@ -492,8 +492,6 @@ def compute_addr(table, no_overlap):
             addr_tmp = write_addr
         if no_overlap:
             addr_tmp = max(read_addr, write_addr)
-            write_addr = addr_tmp
-            write_addr = addr_tmp
 
         #save address temporarily in list
         tmp.append(addr_tmp);
@@ -518,14 +516,3 @@ def compute_addr(table, no_overlap):
     core_addr_w = int(ceil(log(max(read_addr, write_addr), 2)))
 
     return table
-
-
-# top function
-def mkregs(table, hwsw, top, out_dir):
-    table = compute_addr(table, True)
-    if hwsw == "HW":
-        write_hwheader(table, out_dir, top)
-        write_hwcode(table, out_dir, top)
-    elif hwsw == "SW":
-        write_swheader(table, out_dir, top)
-        write_swcode(table, out_dir, top)

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -35,8 +35,8 @@ def setup(top, version, confs, ios, regs, blocks):
     # Generate sw
     #
     mkregs.write_swheader(reg_table, build_dir+'/software/esrc', top)
+    mkregs.write_swcode(reg_table, build_dir+'/software/esrc', top)
     mkregs.write_swheader(reg_table, build_dir+'/software/psrc', top)
-    mkregs.write_swcode(reg_table, build_dir+'/software/psrc', top)
 
     #
     # Generate Tex

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -2,7 +2,7 @@
 
 import sys
 import param_conf as p_conf
-from mkregs import mkregs
+import mkregs
 from verilog2tex import verilog2tex
 from ios import generate_ios_header, generate_ios_tex
 
@@ -11,19 +11,21 @@ src_path = './hardware/src/'
 def setup(top, version, confs, ios, regs, blocks):
 
     #build directory
-    build_dir = f"../{top+'_'+version}";
+    build_dir = f"../{top+'_'+version}"
     
     #build registers table
-    table = []
-    for i in range(len(regs)):
-        table += regs[i]['regs'];
+    reg_table = []
+    for i_regs in regs:
+        reg_table += i_regs['regs']
+
+    reg_table = mkregs.compute_addr(reg_table, True)
 
         
     #
     # Generate hw
     #
-
-    mkregs(table, 'HW', top, build_dir+'/hardware/src')
+    mkregs.write_hwheader(reg_table, build_dir+'/hardware/src', top)
+    mkregs.write_hwcode(reg_table, build_dir+'/hardware/src', top)
     p_conf.params_vh(confs, top, build_dir+'/hardware/src')
     p_conf.conf_vh(confs, top, build_dir+'/hardware/src')
 
@@ -32,8 +34,9 @@ def setup(top, version, confs, ios, regs, blocks):
     #
     # Generate sw
     #
-    mkregs(table, 'SW', top, build_dir+'/software/esrc')
-    mkregs(table, 'SW', top, build_dir+'/software/psrc')
+    mkregs.write_swheader(reg_table, build_dir+'/software/esrc', top)
+    mkregs.write_swheader(reg_table, build_dir+'/software/psrc', top)
+    mkregs.write_swcode(reg_table, build_dir+'/software/psrc', top)
 
     #
     # Generate Tex

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+from os import path
 import param_conf as p_conf
 import mkregs
 from verilog2tex import verilog2tex
@@ -36,7 +37,7 @@ def setup(top, version, confs, ios, regs, blocks):
     #
     mkregs.write_swheader(reg_table, build_dir+'/software/esrc', top)
     mkregs.write_swcode(reg_table, build_dir+'/software/esrc', top)
-    mkregs.write_swheader(reg_table, build_dir+'/software/psrc', top)
+    if path.isdir(build_dir+'/software/psrc'): mkregs.write_swheader(reg_table, build_dir+'/software/psrc', top)
 
     #
     # Generate Tex


### PR DESCRIPTION
The problem with calling the mkregs function multiple times in setup.py is that the first time it was called, it altered the original registers table. The second time mkregs was called, it was trying to alter the register's table again on top of the already altered table.