### PR TITLE
feat(IOs): use normal Verilog IO instead of IOB_ macros

### DIFF
--- a/scripts/if_gen.py
+++ b/scripts/if_gen.py
@@ -304,6 +304,15 @@ def suffix(direction):
         print("ERROR: get_signal_suffix : invalid argument")
         quit()
 
+def remove_iob_macro(direction):
+    if direction == '`IOB_INPUT(':
+        return 'input'
+    elif direction == '`IOB_OUTPUT(':
+        return 'output'
+    else:
+        print("ERROR: remove_iob_macro : invalid argument")
+        quit()
+
 #
 # Port
 #
@@ -311,12 +320,12 @@ def suffix(direction):
 def m_port(prefix, fout):
     for i in range(len(table)):
         if table[i]['master'] == 1:
-            fout.write(' '+table[i]['signal']+prefix+table[i]['name']+suffix(table[i]['signal'])+', '+table[i]['width']+'), //'+top_macro+table[i]['description']+'\n')
+            fout.write(remove_iob_macro(table[i]['signal'])+' ['+table[i]['width']+'-1:0] '+prefix+table[i]['name']+suffix(table[i]['signal'])+', //'+top_macro+table[i]['description']+'\n')
     
 def s_port(prefix, fout):
     for i in range(len(table)):
         if table[i]['slave'] == 1:
-            fout.write(' '+reverse(table[i]['signal'])+prefix+table[i]['name']+suffix(reverse(table[i]['signal']))+', '+table[i]['width']+'), //'+top_macro+table[i]['description']+'\n')
+            fout.write(remove_iob_macro(reverse(table[i]['signal']))+' ['+table[i]['width']+'-1:0] '+prefix+table[i]['name']+suffix(reverse(table[i]['signal']))+', //'+top_macro+table[i]['description']+'\n')
 
 #
 # Portmap

--- a/scripts/ios.py
+++ b/scripts/ios.py
@@ -7,21 +7,21 @@ from latex import write_table
 import if_gen
 
 # Return full port type string based on given types: "I", "O" and "IO"
-# Maps "I", "O" and "IO" to "INPUT", "OUTPUT" and "INOUT", respectively.
+# Maps "I", "O" and "IO" to "input", "outpuT" and "inout", respectively.
 def get_port_type(port_type):
     if port_type == "I":
-        return "INPUT"
+        return "input"
     elif port_type == "O":
-        return "OUTPUT"
+        return "output"
     else:
-        return "INOUT"
+        return "inout"
 
 # Generate io.vh file
 # ios: list of tables, each of them containing a list of ports
 # Each table is a dictionary with fomat: {'name': '<table name>', 'descr':'<table description>', 'ports': [<list of ports>]}
 # Each port is a dictionary with fomat: {'name':"<port name>", 'type':"<port type>", 'n_bits':'<port width>', 'descr':"<port description>"},
 def generate_ios_header(ios, out_dir):
-    f_io = open(f"{out_dir}/io.vh", "w")
+    f_io = open(f"{out_dir}/io.vh", "w+")
 
     for table in ios:
         # Check if this table is a standard interface (from if_gen.py)
@@ -32,7 +32,15 @@ def generate_ios_header(ios, out_dir):
         else:
             # Interface is not standard, read ports
             for port in table['ports']:
-                f_io.write(f"`IOB_{get_port_type(port['type'])}({port['name']}, {port['n_bits']}), //{port['descr']}\n")
+                f_io.write(f"{get_port_type(port['type'])} [{port['n_bits']}-1:0] {port['name']}, //{port['descr']}\n")
+
+    # Find and remove last comma
+    while(f_io.read(1)!=',' and f_io.tell()>1):
+        f_io.seek(f_io.tell()-2)
+    f_io.seek(f_io.tell()-1)
+    if f_io.read(1)==',':
+        f_io.seek(f_io.tell()-1)
+        f_io.write(' ')
 
     f_io.close()
 


### PR DESCRIPTION
- Modify _ios.py_ and _if_gen.py_ to use Verilog `input`, `output`, and `inout`, instead of `IOB_` macros.
- Remove last comma of generated io.vh