### PR TITLE
feat(doc,sw): fix bugs; fix firmware and boot LFLAGS

### DIFF
--- a/document/Makefile
+++ b/document/Makefile
@@ -63,7 +63,7 @@ ug.pdf: debug results ug_figs ugtop.tex
 ugtop.tex:
 	if [ -f confs_tab.tex ]; then echo "\def\CONFS{Y}" >> $@; fi
 	if [ -f td.tex ]; then echo "\def\TD{Y}" >> $@; fi
-	if [ -f swreg.tex ]; then echo "\def\SWREG{Y}" >> $@; fi
+	if [ -f *_swreg_tab.tex ]; then echo "\def\SWREG{Y}" >> $@; fi
 	if [ $(ASICSYNTH) == 1 ]; then echo "\def\ASICSYNTH{Y}" >> $@; fi
 	make doctop DOC=ug
 

--- a/document/tsrc/config.tex
+++ b/document/tsrc/config.tex
@@ -7,17 +7,16 @@ Table~\ref{tab:confs}.
 The configuration entries may be of three types: 'D', 'M' and 'P'.
 
 \begin{itemize}
+    \itemsep-0.5em
     \item The 'D' type is used for defines that apply to all instances of the core.
     \item The 'M' type is used for macros that apply to all instances of the core.
     \item The 'P' type is used for parameters that can vary from instance to instance.
 \end{itemize}
 
-\begin{longtable}{|l|C|c|c|c|p{9cm}|}
+\begin{longtable}{|l|c|c|c|c|p{9cm}|}
     \caption{Configuration Macros}\label{tab:confs}\\ \hline
     \rowcolor{iob-green}
     {\bf Macro} & {\bf Type} & {\bf Min} & {\bf Typ} & {\bf Max} & {\bf Description}
     \\ \hline \hline
     \input confs_tab
 \end{longtable}
-\fi
-

--- a/document/tsrc/swreg.tex
+++ b/document/tsrc/swreg.tex
@@ -4,5 +4,5 @@
     \caption{Software Accessible Registers}\label{tab:sw_tx}\\ \hline
     \rowcolor{iob-green}
     {\bf Name} & {\bf R/W} & {\bf Addr} & {\bf Bits} & {\bf Initial Value} & {\bf Description} \\ \hline
-    \input{*_swreg_tab}
+    \input _swreg_tab
 \end{longtable}

--- a/hardware/simulation/icarus.mk
+++ b/hardware/simulation/icarus.mk
@@ -18,4 +18,6 @@ exec:
 clean: gen-clean
 	@rm -f a.out
 
-.PHONY: comp exec clean
+very-clean: clean
+
+.PHONY: comp exec clean very-clean

--- a/scripts/ios.py
+++ b/scripts/ios.py
@@ -111,7 +111,7 @@ def generate_if_tex(ios, out_dir):
     \input '''+table['name']+'''_if_tab
  
   \end{tabular}
-  \caption{'''+table['descr']+'''}
+  \caption{'''+table['descr'].replace('_','\_')+'''}
   \label{'''+table['name']+'''_if_tab:is}
 \end{table}
 '''

--- a/software/embedded/Makefile
+++ b/software/embedded/Makefile
@@ -19,8 +19,9 @@ endif
 #compiler settings
 TOOLCHAIN_PREFIX:=riscv64-unknown-elf-
 CFLAGS=-Os -nostdlib -march=$(MFLAGS) -mabi=ilp32 --specs=nano.specs -Wcast-align=strict
-FW_LFLAGS= -Wl,-Bstatic,-T,$(TEMPLATE_LDS),--strip-debug
-BOOT_LFLAGS+= -Wl,-Map,boot.map
+LFLAGS= -Wl,-Bstatic,-T,$(TEMPLATE_LDS),--strip-debug
+FW_LFLAGS+=$(LFLAGS) -Wl,-Map,firmware.map
+BOOT_LFLAGS+=$(LFLAGS) -Wl,-Map,boot.map
 LLIBS=-lgcc -lc -lnosys
 INCLUDES=-I. -I../esrc
 DEFINES=

--- a/software/pc-emul/Makefile
+++ b/software/pc-emul/Makefile
@@ -21,6 +21,7 @@ HDR=$(wildcard *.h)
 HDR+=$(wildcard ../psrc/*.h)
 
 SRC=$(wildcard *.c)
+SRC=$(wildcard ../firmware/*)
 SRC+=$(wildcard ../psrc/*.c)
 
 # include local pc-emul segment

--- a/software/pc-emul/Makefile
+++ b/software/pc-emul/Makefile
@@ -21,7 +21,7 @@ HDR=$(wildcard *.h)
 HDR+=$(wildcard ../psrc/*.h)
 
 SRC=$(wildcard *.c)
-SRC=$(wildcard ../firmware/*)
+SRC=$(wildcard ../firmware/*.c)
 SRC+=$(wildcard ../psrc/*.c)
 
 # include local pc-emul segment


### PR DESCRIPTION
- Fix documentation makefile segments
  - Fix column in longtable
  - Make swreg optional by checking if there are any *_swreg_tab.tex files. The 'swreg.tex' file is always copied by 'setup.mk' if it doesn't exist.
- Include sources from the firmware source directory, the same way it is done in the embedded firmware Makefile.
- Fix firmware and boot LFLAGS