### PR TITLE
feat(console;verilator): rename console script to console.py; include embedded sources.

### DIFF
--- a/hardware/fpga/Makefile
+++ b/hardware/fpga/Makefile
@@ -94,7 +94,7 @@ endif
 
 
 #console start command
-CONSOLE_CMD=$(PYTHON_DIR)/console -s /dev/usb-uart
+CONSOLE_CMD=$(PYTHON_DIR)/console.py -s /dev/usb-uart
 ifeq ($(INIT_MEM),0)
 CONSOLE_CMD+=-f
 endif

--- a/hardware/simulation/verilator.mk
+++ b/hardware/simulation/verilator.mk
@@ -2,6 +2,8 @@ VTOP?=$(NAME)
 
 VFLAGS+=--cc --exe -I. -I../src -Isrc --top-module $(VTOP)
 VFLAGS+=-Wno-lint
+# Include embedded headers
+VFLAGS+=-CFLAGS "-I../../../software/esrc"
 
 ifeq ($(VCD),1)
 VFLAGS+=--trace
@@ -19,5 +21,7 @@ exec:
 
 clean: gen-clean
 	@rm -rf obj_dir
+
+very-clean: clean
 
 .PHONY: comp exec clean

--- a/scripts/console.py
+++ b/scripts/console.py
@@ -145,7 +145,7 @@ def endFileTransfer():
     FRX = None
 
 def usage(message):
-    print('{}:{}'.format(PROGNAME, "usage: ./console -s <serial port> [ -f ] [ -L/--local ]"))
+    print('{}:{}'.format(PROGNAME, "usage: ./console.py -s <serial port> [ -f ] [ -L/--local ]"))
     cnsl_perror(message)
 
 def clean_exit():

--- a/software/pc-emul/Makefile
+++ b/software/pc-emul/Makefile
@@ -12,7 +12,7 @@ endif
 # compiler flags
 CFLAGS=-Os -std=gnu99 -Wl,--strip-debug
 
-CONSOLE_CMD=../../scripts/console -L
+CONSOLE_CMD=../../scripts/console.py -L
 
 INCLUDE=-I.
 INCLUDE+=-I../src


### PR DESCRIPTION
- Rename console file to console.py
- Add CFLAGS to include embedded headers for simulation testbench.
- Add very-clean target. This target is required for simulation (called from simulation Makefile).