### PR TITLE
feat(mkregs,doc): Add ternary operator to mkregs IO; Remove sw.tex.

### DIFF
--- a/document/tsrc/sw.tex
+++ b/document/tsrc/sw.tex
@@ -1,5 +1,0 @@
-The software accessible registers of the core are described in the following
-tables. The tables give information on the name, read/write capability, address, width in bits, and a textual description.
-
-\input{swreg}
-

--- a/document/tsrc/ug.tex
+++ b/document/tsrc/ug.tex
@@ -69,7 +69,7 @@ User Guide, \input{\NAME_version.tex}, Build \input{shortHash.tex}
 \ifdefined\SWREG
 \subsection{Software Accessible Registers}
 \label{sec:swreg}
-\input{sw}
+\input{swreg}
 \fi
 
 \section{Usage}

--- a/scripts/mkregs.py
+++ b/scripts/mkregs.py
@@ -110,11 +110,11 @@ def gen_port(table, f):
  
         
         if row['type'] == 'W':
-            f.write(f"\t`IOB_OUTPUT({name}_o, {n_bits}),\n")
+            f.write(f"\t`IOB_OUTPUT({name}_o, {verilog_max(n_bits,1)}),\n")
             if not auto:
                 f.write(f"\t`IOB_OUTPUT({name}_wen_o, 1),\n")
         elif row['type'] == 'R':
-            f.write(f"\t`IOB_INPUT({name}_i, {n_bits}),\n")
+            f.write(f"\t`IOB_INPUT({name}_i, {verilog_max(n_bits,1)}),\n")
             if not auto:
                 f.write(f"\t`IOB_OUTPUT({name}_ren_o, 1),\n")
                 f.write(f"\t`IOB_INPUT({name}_rvalid_i, 1),\n")
@@ -137,11 +137,11 @@ def gen_inst_wire(table, f):
         rst_val = row['rst_val']
 
         if row['type'] == 'W':
-            f.write(f"`IOB_WIRE({name}, {n_bits})\n")
+            f.write(f"`IOB_WIRE({name}, {verilog_max(n_bits,1)})\n")
             if not auto:
                 f.write(f"`IOB_WIRE({name}_wen, 1)\n")
         elif row['type'] == 'R':
-            f.write(f"`IOB_WIRE({name}, {n_bits})\n")
+            f.write(f"`IOB_WIRE({name}, {verilog_max(n_bits,1)})\n")
             if not row['autologic']:
                 f.write(f"`IOB_WIRE({name}_rvalid, 1)\n")
                 f.write(f"`IOB_WIRE({name}_ren, 1)\n")
@@ -613,6 +613,13 @@ def compute_addr(table, no_overlap):
 # Generate swreg.tex file with list TeX tables of regs
 def generate_swreg_tex(regs, out_dir):
     swreg_file = open(f"{out_dir}/swreg.tex", "w")
+
+    swreg_file.write(\
+'''
+The software accessible registers of the core are described in the following
+tables. The tables give information on the name, read/write capability, address, width in bits, and a textual description.
+'''
+    )
 
     for table in regs:
         swreg_file.write(\


### PR DESCRIPTION
- Add conditional operator to the IOs of swreg modules to ensure signal widths are greater than zero.
- Remove _sw.tex_ file. Include its contents in the _swreg.tex_ file generated by _mkregs.py_