### PR TITLE
Fixed console serial port declaration

### DIFF
--- a/software/python/console
+++ b/software/python/console
@@ -196,7 +196,7 @@ def init_serial():
 
     # configure the serial connections (the parameters differs on the device connected to)
     ser = serial.Serial()
-    ser.port = "/dev/usb-uart"         # serial port
+    ser.port = sys.argv[sys.argv.index('-s')+1] #serial port from -s argument
     if ('-b' in sys.argv):
         if (len(sys.argv)<5): usage("PROGNAME: not enough program arguments")
         ser.baudrate = sys.argv[sys.argv.index('-b')+1]              # baudrate


### PR DESCRIPTION
The current `console` script hardcodes the serial port to `/dev/usb-uart`.
From my testing, the script has an argument to provide that (`-s`).

This PR replaces the hardcoded value to the one provided by the user argument.