### PR TITLE
Add target to build `alt_ddr3.qip` for CYCLONEV 

### DIFF
--- a/hardware/fpga/Makefile
+++ b/hardware/fpga/Makefile
@@ -27,8 +27,8 @@ ifneq ($(wildcard fpga_build.mk),)
 include fpga_build.mk
 endif
 
-include $(FPGA_TOOL)/$(FPGA_TOOL).mk
 include $(FPGA_TOOL)/$(BOARD)/board.mk
+include $(FPGA_TOOL)/$(FPGA_TOOL).mk
 
 #include the module's headers and sources
 VHDR=$(wildcard ../src/*.vh)

--- a/hardware/fpga/Makefile
+++ b/hardware/fpga/Makefile
@@ -100,7 +100,7 @@ release-remote:
 ifeq ($(BOARD_SERVER),)
 	make release
 else
-	ssh $(BOARD_USER)@$(BOARD_SERVER) 'make -C $(REMOTE_FPGA_DIR)/$(TOOL)/$(BOARD) release'
+	ssh $(BOARD_USER)@$(BOARD_SERVER) 'make -C $(REMOTE_FPGA_DIR)/$(FPGA_TOOL)/$(BOARD) release'
 endif
 
 

--- a/hardware/fpga/quartus/CYCLONEV-GT-DK/board.mk
+++ b/hardware/fpga/quartus/CYCLONEV-GT-DK/board.mk
@@ -1,2 +1,11 @@
 BOARD_SERVER=$(CYC5_SERVER)
 BOARD_USER=$(CYC5_USER)
+
+QIP_FILE=$(FPGA_TOOL)/$(BOARD)/alt_ddr3.qip
+
+ifeq ($(USE_DDR),1)
+FPGA_DEPS+=$(QIP_FILE)
+endif
+
+$(QIP_FILE): $(FPGA_TOOL)/$(BOARD)/alt_ddr3.qsys
+	$(FPGA_ENV) qsys-generate --synthesis $<

--- a/hardware/fpga/quartus/CYCLONEV-GT-DK/board.mk
+++ b/hardware/fpga/quartus/CYCLONEV-GT-DK/board.mk
@@ -3,7 +3,7 @@ BOARD_USER=$(CYC5_USER)
 
 QIP_FILE=$(FPGA_TOOL)/$(BOARD)/alt_ddr3.qip
 
-ifeq ($(USE_DDR),1)
+ifeq ($(USE_EXTMEM),1)
 FPGA_DEPS+=$(QIP_FILE)
 endif
 

--- a/hardware/fpga/quartus/CYCLONEV-GT-DK/device.tcl
+++ b/hardware/fpga/quartus/CYCLONEV-GT-DK/device.tcl
@@ -2,6 +2,6 @@ set_global_assignment -name FAMILY "Cyclone V"
 set_global_assignment -name DEVICE 5CGTFD9E5F35C7
 set_global_assignment -name IOBANK_VCCIO 1.5V -section_id 4A
 
-if { $USE_DDR > 0 } {
+if { $USE_EXTMEM > 0 } {
 	set_global_assignment -name QIP_FILE quartus/$BOARD/alt_ddr3.qip
 }

--- a/hardware/fpga/quartus/CYCLONEV-GT-DK/device.tcl
+++ b/hardware/fpga/quartus/CYCLONEV-GT-DK/device.tcl
@@ -1,3 +1,7 @@
 set_global_assignment -name FAMILY "Cyclone V"
 set_global_assignment -name DEVICE 5CGTFD9E5F35C7
 set_global_assignment -name IOBANK_VCCIO 1.5V -section_id 4A
+
+if { $USE_DDR > 0 } {
+	set_global_assignment -name QIP_FILE quartus/$BOARD/alt_ddr3.qip
+}

--- a/hardware/fpga/quartus/build.tcl
+++ b/hardware/fpga/quartus/build.tcl
@@ -4,7 +4,7 @@ set BOARD [lindex $argv 1]
 set VSRC [lindex $argv 2]
 set QIP [lindex $argv 3]
 set IS_FPGA [lindex $argv 4]
-set RUN_EXTMEM [lindex $argv 5]
+set USE_DDR [lindex $argv 5]
 
 project_new $NAME -overwrite
 

--- a/hardware/fpga/quartus/build.tcl
+++ b/hardware/fpga/quartus/build.tcl
@@ -4,7 +4,7 @@ set BOARD [lindex $argv 1]
 set VSRC [lindex $argv 2]
 set QIP [lindex $argv 3]
 set IS_FPGA [lindex $argv 4]
-set USE_DDR [lindex $argv 5]
+set USE_EXTMEM [lindex $argv 5]
 
 project_new $NAME -overwrite
 

--- a/hardware/fpga/quartus/quartus.mk
+++ b/hardware/fpga/quartus/quartus.mk
@@ -13,7 +13,7 @@ FPGA_ENV=$(QUARTUSPATH)/nios2eds/nios2_command_shell.sh
 FPGA_PROG=$(FPGA_ENV) quartus_pgm -m jtag -c 1 -o 'p;$(NAME)_fpga_wrapper.sof'
 
 $(FPGA_OBJ): $(VHDR) $(VSRC) $(wildcard *.sdc) $(FPGA_DEPS)
-	$(FPGA_ENV) quartus_sh -t quartus/build.tcl $(NAME)_fpga_wrapper $(BOARD) "$(VSRC)" "None" $(IS_FPGA) $(USE_DDR)
+	$(FPGA_ENV) quartus_sh -t quartus/build.tcl $(NAME)_fpga_wrapper $(BOARD) "$(VSRC)" "None" $(IS_FPGA) $(USE_EXTMEM)
 	@mv output_files/*.fit.summary $(FPGA_LOG)
 	@mv output_files/$(FPGA_OBJ) $(FPGA_OBJ)
 

--- a/hardware/fpga/quartus/quartus.mk
+++ b/hardware/fpga/quartus/quartus.mk
@@ -12,8 +12,8 @@ FPGA_USER=$(QUARTUS_USER)
 FPGA_ENV=$(QUARTUSPATH)/nios2eds/nios2_command_shell.sh
 FPGA_PROG=$(FPGA_ENV) quartus_pgm -m jtag -c 1 -o 'p;$(NAME)_fpga_wrapper.sof'
 
-$(FPGA_OBJ): $(VHDR) $(VSRC) $(wildcard *.sdc)
-	$(FPGA_ENV) quartus_sh -t quartus/build.tcl $(NAME)_fpga_wrapper $(BOARD) "$(VSRC)" "None" $(IS_FPGA)
+$(FPGA_OBJ): $(VHDR) $(VSRC) $(wildcard *.sdc) $(FPGA_DEPS)
+	$(FPGA_ENV) quartus_sh -t quartus/build.tcl $(NAME)_fpga_wrapper $(BOARD) "$(VSRC)" "None" $(IS_FPGA) $(USE_DDR)
 	@mv output_files/*.fit.summary $(FPGA_LOG)
 	@mv output_files/$(FPGA_OBJ) $(FPGA_OBJ)
 

--- a/hardware/fpga/vivado/build.tcl
+++ b/hardware/fpga/vivado/build.tcl
@@ -9,7 +9,7 @@ puts $NAME
 puts $BOARD
 puts $VSRC
 puts $IS_FPGA
-puts $RUN_EXTMEM
+puts $CUSTOM_ARGS
 
 
 #verilog sources

--- a/hardware/fpga/vivado/vivado.mk
+++ b/hardware/fpga/vivado/vivado.mk
@@ -16,7 +16,7 @@ FPGA_PROG=$(FPGA_ENV) && $(VIVADOPATH)/bin/vivado -nojournal -log vivado.log -mo
 export RDI_VERBOSE = False
 
 $(FPGA_OBJ): $(VSRC) $(VHDR) $(wildcard *.sdc)
-	$(FPGA_ENV) && $(VIVADOPATH)/bin/vivado -nojournal -log vivado.log -mode batch -source vivado/build.tcl -tclargs $(NAME)_fpga_wrapper $(BOARD) "$(VSRC)" $(IS_FPGA) $(RUN_EXTMEM)
+	$(FPGA_ENV) && $(VIVADOPATH)/bin/vivado -nojournal -log vivado.log -mode batch -source vivado/build.tcl -tclargs $(NAME)_fpga_wrapper $(BOARD) "$(VSRC)" $(IS_FPGA) $(USE_DDR)
 
 vivado-clean:
 	@rm -rf .Xil

--- a/hardware/fpga/vivado/vivado.mk
+++ b/hardware/fpga/vivado/vivado.mk
@@ -16,7 +16,7 @@ FPGA_PROG=$(FPGA_ENV) && $(VIVADOPATH)/bin/vivado -nojournal -log vivado.log -mo
 export RDI_VERBOSE = False
 
 $(FPGA_OBJ): $(VSRC) $(VHDR) $(wildcard *.sdc)
-	$(FPGA_ENV) && $(VIVADOPATH)/bin/vivado -nojournal -log vivado.log -mode batch -source vivado/build.tcl -tclargs $(NAME)_fpga_wrapper $(BOARD) "$(VSRC)" $(IS_FPGA) $(USE_DDR)
+	$(FPGA_ENV) && $(VIVADOPATH)/bin/vivado -nojournal -log vivado.log -mode batch -source vivado/build.tcl -tclargs $(NAME)_fpga_wrapper $(BOARD) "$(VSRC)" $(IS_FPGA) $(USE_EXTMEM)
 
 vivado-clean:
 	@rm -rf .Xil

--- a/scripts/mk_configuration.py
+++ b/scripts/mk_configuration.py
@@ -110,7 +110,9 @@ def config_for_board(top, flows_list, build_dir):
     available_configs = {
         'CYCLONEV-GT-DK':{'BAUD':'115200', 'FREQ':'50000000', 'MEM_NO_READ_ON_WRITE':'1', 'DDR_DATA_W':'32', 'DDR_ADDR_W':'30'}, 
         'AES-KU040-DB-G':{'BAUD':'115200', 'FREQ':'100000000', 'DDR_DATA_W':'32', 'DDR_ADDR_W':'30'},
-        'SIMULATION':{'BAUD':'3000000', 'FREQ':'100000000', 'DDR_DATA_W':'32', 'DDR_ADDR_W':'24'}
+        'DE10-LITE':{'BAUD':'115200', 'FREQ':'50000000', 'DDR_DATA_W':'0', 'DDR_ADDR_W':'0'},
+        'BASYS3':{'BAUD':'115200', 'FREQ':'100000000', 'DDR_DATA_W':'0', 'DDR_ADDR_W':'0'},
+        'SIMULATION':{'BAUD':'3000000', 'FREQ':'100000000', 'DDR_DATA_W':'32', 'DDR_ADDR_W':'24'},
         }
 
     # Set config based on value of BOARD variable


### PR DESCRIPTION
- Add target to build `alt_ddr3.qip` for CYCLONEV.
- Rename 'RUN_EXTMEM' to 'USE_DDR' for FPGA related components, as they may be used in other cores that do not necessarily run from external memory.
- Add settings for BASYS3 and DE10-LITE.