### PR TITLE
Specify lamba function types during setup; Remove unused `uut_name` tester option.

### DIFF
--- a/scripts/build_srcs.py
+++ b/scripts/build_srcs.py
@@ -69,8 +69,6 @@ def hw_setup(python_module):
     # create module's *_version.vh Verilog Header
     version_file(core_name, core_version, core_previous_version, build_dir)
 
-    #Add lambda functions to the hw_srcs. These functions call setup modules for hardware setup (hw_setup.py)
-    add_setup_lambdas(python_module,setup_module=python_module)
     #Setup any hw submodules by calling the 'main()' function from their *_setup.py module
     module_dependency_setup(hardware_srcs, Vheaders, build_dir, submodule_dirs, lib_dir=LIB_DIR)
 
@@ -108,7 +106,7 @@ def sim_setup(python_module):
         shutil.copytree(f"{setup_dir}/{sim_dir}", f"{build_dir}/{sim_dir}", dirs_exist_ok=True, copy_function=copy_without_override, ignore=shutil.ignore_patterns('*_setup*'))
 
     #Add lambda functions to the sim_srcs. These functions call setup modules for simulation setup (sim_setup.py)
-    add_setup_lambdas(python_module,setup_module=python_module)
+    add_setup_lambdas(python_module,'sim_setup',setup_module=python_module)
     #Setup any sim submodules by calling the 'sim_setup()' function from their *_setup.py module
     module_dependency_setup(sim_srcs, Vheaders, build_dir, submodule_dirs, function_2_call="setup.build_srcs.sim_setup", lib_dir=LIB_DIR) 
 
@@ -145,7 +143,7 @@ def fpga_setup(python_module):
         shutil.copytree(f"{setup_dir}/{fpga_dir}", f"{build_dir}/{fpga_dir}", dirs_exist_ok=True, copy_function=copy_without_override, ignore=shutil.ignore_patterns('*_setup*'))
 
     #Add lambda functions to the fpga_srcs. These functions call setup modules for fpga setup (fpga_setup.py)
-    add_setup_lambdas(python_module,setup_module=python_module)
+    add_setup_lambdas(python_module,'fpga_setup',setup_module=python_module)
     #Setup any fpga submodules by calling the 'fpga_setup()' function from their *_setup.py module
     module_dependency_setup(fpga_srcs, Vheaders, build_dir, submodule_dirs, function_2_call="setup.build_srcs.fpga_setup", lib_dir=LIB_DIR) 
 
@@ -193,17 +191,17 @@ def syn_setup(python_module):
 # This will allow these modules to be executed during setup
 #    python_module: python module of *_setup.py of the core/system, should contain setup_dir
 #    **kwargs: set of objects that will be accessible from inside the modules when they are executed
-def add_setup_lambdas(python_module, **kwargs):
+def add_setup_lambdas(python_module, module_type, **kwargs):
     # Check if any *_setup.py modules exist. If so, get a lambda expression to execute them and add them to the 'modules' list
-    for module_type, module_path in [('sim_setup','hardware/simulation/sim_setup.py'), ('fpga_setup','hardware/fpga/fpga_setup.py'), ('sw_setup','software/sw_setup.py')]:
-        full_module_path = os.path.join(python_module.setup_dir,module_path)
-        if os.path.isfile(full_module_path): 
-            # Make sure dictionary exists
-            if module_type not in python_module.submodules: 
-                python_module.submodules[module_type] = {'headers':[], 'modules':[]}
-            # Append executable module to 'modules' list of the submodules dictionary
-            # The lambda expression will be executed during setup
-            python_module.submodules[module_type]['modules'].append(get_module_lambda(full_module_path, **kwargs))
+    module_path = {'sim_setup':'hardware/simulation/sim_setup.py', 'fpga_setup':'hardware/fpga/fpga_setup.py', 'sw_setup':'software/sw_setup.py'}[module_type]
+    full_module_path = os.path.join(python_module.setup_dir,module_path)
+    if os.path.isfile(full_module_path): 
+        # Make sure dictionary exists
+        if module_type not in python_module.submodules: 
+            python_module.submodules[module_type] = {'headers':[], 'modules':[]}
+        # Append executable module to 'modules' list of the submodules dictionary
+        # The lambda expression will be executed during setup
+        python_module.submodules[module_type]['modules'].append(get_module_lambda(full_module_path, **kwargs))
 
 #Get an executable lambda expression to run a given python module
 #    module_path: python module path
@@ -247,7 +245,7 @@ def sw_setup(python_module):
         shutil.copytree(f"{setup_dir}/software", f"{build_dir}/software", dirs_exist_ok=True, copy_function=copy_without_override, ignore=shutil.ignore_patterns('*_setup*'))
 
     #Add lambda functions to the sw_srcs. These functions call setup modules for software setup (sw_setup.py)
-    add_setup_lambdas(python_module,setup_module=python_module)
+    add_setup_lambdas(python_module,'sw_setup',setup_module=python_module)
     #Setup any sw submodules by calling the 'sw_setup()' function from their *_setup.py module
     module_dependency_setup(sw_srcs, Cheaders, build_dir, submodule_dirs, function_2_call="setup.build_srcs.sw_setup", lib_dir=LIB_DIR) 
 

--- a/scripts/tester.py
+++ b/scripts/tester.py
@@ -197,17 +197,6 @@ def setup_tester( python_module ):
     # Call setup function for the tester
     setup(python_module, peripheral_ios=False, internal_wires=peripheral_wires)
 
-    # Add hardware build macros with same value as the ones for the UUT
-    if 'uut_name' in module_parameters.keys():
-        with open(f"{python_module.build_dir}/hardware/src/{python_module.name}_conf.vh", 'r+') as file:
-            contents = file.readlines()
-            contents.insert(-1,f"`define IOB_SOC_TESTER_DDR_ADDR_W `{module_parameters['uut_name'].upper()}_DDR_ADDR_W\n")
-            contents.insert(-1,f"`define IOB_SOC_TESTER_DDR_DATA_W `{module_parameters['uut_name'].upper()}_DDR_DATA_W\n")
-            contents.insert(-1,f"`define IOB_SOC_TESTER_FREQ `{module_parameters['uut_name'].upper()}_FREQ\n")
-            contents.insert(-1,f"`define IOB_SOC_TESTER_BAUD `{module_parameters['uut_name'].upper()}_BAUD\n")
-            file.seek(0)
-            file.writelines(contents)
-
     #Check if setup with INIT_MEM and USE_EXTMEM (check if macro exists)
     extmem_macro = next((i for i in confs if i['name']=='USE_EXTMEM'), False)
     initmem_macro = next((i for i in confs if i['name']=='INIT_MEM'), False)
@@ -221,8 +210,6 @@ def setup_tester( python_module ):
             file.write("init_ddr_contents.hex: iob_soc_tester_firmware.hex\n")
 
             sut_firmware_name = module_parameters['sut_fw_name'].replace('.c','')+'.hex' if 'sut_fw_name' in module_parameters.keys() else '-'
-            if 'uut_name' in module_parameters.keys(): ddr_macro_name = f"{module_parameters['uut_name'].upper()}_DDR_ADDR_W"
-            else: ddr_macro_name = "IOB_SOC_TESTER_DDR_ADDR_W"
-            file.write(f"	../../scripts/joinHexFiles.py {sut_firmware_name} $^ $(call GET_MACRO,{ddr_macro_name},../src/build_configuration.vh) > $@\n")
+            file.write(f"	../../scripts/joinHexFiles.py {sut_firmware_name} $^ $(call GET_MACRO,DDR_ADDR_W,../src/build_configuration.vh) > $@\n")
         # Copy joinHexFiles.py from LIB
         build_srcs.copy_files( "submodules/LIB", f"{python_module.build_dir}/scripts", [ "joinHexFiles.py" ], '*.py' )


### PR DESCRIPTION
- Specify which type of script to add as a lambda function ('sim_setup','fpga_setup' or 'sw_setup'). This prevents duplicate  lambda functions in the same lists. It fixes issue that was causing `fpga_setup.py` to be called multiple times.
- Remove unused 'uut_name' tester option.