### PR TITLE
Update `riscv-gnu-toolchain.nix`; Update import_setup() function; Clean 'sopc_altera_pll*' folders.

### DIFF
--- a/hardware/fpga/quartus/build.mk
+++ b/hardware/fpga/quartus/build.mk
@@ -19,5 +19,6 @@ $(FPGA_OBJ): $(VHDR) $(VSRC) $(QIP) $(wildcard *.sdc)
 
 quartus-clean:
 	@rm -rf incremental_db db output_files
+	@find ~ -maxdepth 1 -type d -empty -iname "sopc_altera_pll*" -delete
 
 .PHONY: quartus-clean

--- a/hardware/fpga/quartus/build.tcl
+++ b/hardware/fpga/quartus/build.tcl
@@ -33,9 +33,9 @@ set_global_assignment -name VERILOG_INPUT_VERSION SYSTEMVERILOG_2005
 set_global_assignment -name SEARCH_PATH ../src
 
 #quartus IPs
-foreach file [split $QIP \ ] {
-    if { { file extension $QIP } == ".qip"} {
-        set_global_assignment -name QIP_FILE $file
+foreach qip_file [split $QIP \ ] {
+    if { [ file extension $qip_file ] == ".qip"} {
+        set_global_assignment -name QIP_FILE $qip_file
     }
 }
 

--- a/nix/riscv-gnu-toolchain.nix
+++ b/nix/riscv-gnu-toolchain.nix
@@ -1,91 +1,60 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, util-linux
-, git
-, cacert
-, autoconf
-, automake
-, curl
-, python3
-, gawk
-, bison
-, flex
-, texinfo
-, gperf
-, bc
-, libmpc
-, mpfr
-, gmp
-, zlib
-, expat
-}:
+{ pkgs ? import <nixpkgs> {} }:
 
-stdenv.mkDerivation rec {
-  pname = "riscv-gnu-toolchain";
-  version = "2022.11.23";
-
-  src = fetchFromGitHub {
-    owner = "riscv-collab";
+pkgs.stdenv.mkDerivation {
+  name = "riscv-gnu-toolchain";
+  src = pkgs.fetchFromGitHub {
     repo = "riscv-gnu-toolchain";
-    rev = "${version}";
-    sha256 = "sha256-5BWWbjQ65/tDpWmY9r+oA013OhVkjga8GCLK90ZXe5k=";
-    leaveDotGit = true;
+    owner = "riscv-collab";
+    rev = "2022.06.10";
+    fetchSubmodules = true;
+    #leaveDotGit = true; #This is not deterministic, causes issues with hash. https://github.com/NixOS/nixpkgs/issues/8567
+    sha256 = "sha256-KjbVnUfvk7JEWsFPz7x7HZolAJ/PvQaBEwAoF/G0lQw=";
   };
-
-  postPatch = ''
-    # hack for unknown issue in fetchgit
-    git reset --hard
-    patchShebangs ./scripts
+  buildInputs = [ 
+     pkgs.gmp
+     pkgs.libmpc
+     pkgs.mpfr
+   ];
+  nativeBuildInputs = [
+     pkgs.gcc
+     pkgs.python3
+     pkgs.util-linux
+     pkgs.git
+     pkgs.cacert
+     pkgs.autoconf
+     pkgs.automake
+     pkgs.curl
+     pkgs.python3
+     pkgs.gawk
+     pkgs.bison
+     pkgs.flex
+     pkgs.texinfo
+     pkgs.gperf
+     pkgs.bc
+     pkgs.perl
+     pkgs.expat
+  ];
+  buildPhase = ''
+    # Build in /tmp dir because the Nix tmpfs build/ partition does not have enough space to build this toolchain
+    rm -fr /tmp/`basename $src`
+    cp -r $src /tmp/`basename $src`
+    cd /tmp/`basename $src`
+    chmod +w -R .
+    # Hack to manually create git reposiories because .git folders were deleted by leaveDotGit=false
+    for path in "." "riscv-gcc" "riscv-gdb" "riscv-binutils" "newlib"; do
+        env -C $path git init --initial-branch=main;
+    done
+    ./configure --prefix=$out --enable-multilib
+    make -j$(nproc)
+  '';
+  installPhase = ''
+    cd /tmp/`basename $src`
+    make install
   '';
 
-  nativeBuildInputs = [
-    python3
-    util-linux
-    git
-    cacert
-    autoconf
-    automake
-    curl
-    python3
-    gawk
-    bison
-    flex
-    texinfo
-    gperf
-    bc
-  ];
+  clean = ''
+    rm -fr /tmp/`basename $src`
+  '';
 
-  buildInputs = [
-    libmpc
-    mpfr
-    gmp
-    zlib
-    expat
-  ];
-
-  configureFlags = [
-    "--enable-multilib"
-  ];
-
-  makeFlags = [
-    "newlib"
-    "linux"
-  ];
-
-  hardeningDisable = [
-    "format"
-  ];
-
-  enableParallelBuilding = true;
-
-  __noChroot = true;
-
-  meta = with lib; {
-    description = "This is the RISC-V C and C++ cross-compiler. It supports two build modes: a generic ELF/Newlib toolchain and a more sophisticated Linux-ELF/glibc toolchain.";
-    homepage = "https://github.com/riscv-collab/riscv-gnu-toolchain";
-    license = licenses.gpl2;
-    maintainers = with maintainers; [  ];
-    platforms = platforms.linux;
-  };
+  hardeningDisable = [ "format" ];
 }

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -3,6 +3,7 @@ pkgs.mkShell {
   name = "iob-soc-shell";
   buildInputs = with pkgs; [     
     bash
+    gnumake
     verilog
     verilator
     gtkwave

--- a/scripts/build_srcs.py
+++ b/scripts/build_srcs.py
@@ -311,10 +311,9 @@ def submodule_setup(build_dir, submodule_dir, module_parameters=None, function_2
 def iob_submodule_setup(build_dir, submodule_dir, module_parameters=None, function_2_call='main'):
     #print(f"################# {function_2_call}") #DEBUG
     #Import <corename>_setup.py
-    module = import_setup(submodule_dir)
+    module = import_setup(submodule_dir, module_parameters=module_parameters)
     module.build_dir = build_dir
     module.setup_dir = submodule_dir
-    module.module_parameters = module_parameters
     # Split string to check if function is inside a module
     function_2_call=function_2_call.split('.')
     # Check if function is inside other module(s)

--- a/scripts/createSystem.py
+++ b/scripts/createSystem.py
@@ -5,9 +5,9 @@ import sys, os
 from submodule_utils import *
 import ios
 
-# Automatically include <corename>_swreg_def.vh verilog headers after PHEADER comment
+# Automatically include <corename>_swreg_def.vh verilog headers after IOB_PRAGMA_PHEADERS comment
 def insert_header_files(template_contents, peripherals_list, submodule_dirs):
-    header_index = find_idx(template_contents, "PHEADER")
+    header_index = find_idx(template_contents, "IOB_PRAGMA_PHEADERS")
     # Get each type of peripheral used
     included_peripherals = []
     for instance in peripherals_list:
@@ -45,7 +45,7 @@ def create_systemv(setup_dir, submodule_dirs, top, peripherals_list, out_file, i
     # Insert IOs and Instances for this type of peripheral
     for instance in peripherals_list:
         # Insert peripheral instance (in reverse order of lines)
-        start_index = find_idx(template_contents, "endmodule")-1
+        start_index = find_idx(template_contents, "IOB_PRAGMA_PERIPHS")
         template_contents.insert(start_index, "      );\n")
 
         # Insert reserved signals

--- a/scripts/createTopSystem.py
+++ b/scripts/createTopSystem.py
@@ -28,7 +28,7 @@ def create_top_system(setup_dir, submodule_dirs, top, peripherals_list, ios, con
         pio_signals = get_pio_signals(table['ports'])
 
         # Insert system IOs for peripheral
-        start_index = find_idx(template_contents, "PWIRES")
+        start_index = find_idx(template_contents, "IOB_PRAGMA_PWIRES")
         if pio_signals and 'if_defined' in table.keys(): template_contents.insert(start_index, "`endif\n")
         for signal in pio_signals:
             template_contents.insert(start_index, '   wire [{}-1:0] {}_{};\n'.format(add_prefix_to_parameters_in_string(signal['n_bits'],confs,"`"+top.upper()+"_"),
@@ -37,7 +37,7 @@ def create_top_system(setup_dir, submodule_dirs, top, peripherals_list, ios, con
         if pio_signals and 'if_defined' in table.keys(): template_contents.insert(start_index, f"`ifdef {table['if_defined']}\n")
 
         # Connect wires to soc port
-        start_index = find_idx(template_contents, "PORTS")
+        start_index = find_idx(template_contents, "IOB_PRAGMA_PPORTMAPS")
         if pio_signals and 'if_defined' in table.keys(): template_contents.insert(start_index, "`endif\n")
         for signal in pio_signals:
             template_contents.insert(start_index, '               .{signal}({signal}),\n'.format(signal=table['name']+"_"+signal['name']))

--- a/scripts/mk_configuration.py
+++ b/scripts/mk_configuration.py
@@ -113,11 +113,11 @@ def generate_confs_tex(confs, out_dir):
 #build_dir: path to build directory
 def config_for_board(top, flows_list, build_dir):
     available_configs = {
-        'CYCLONEV-GT-DK':{'BAUD':'115200', 'FREQ':'50000000', 'MEM_NO_READ_ON_WRITE':'1', 'DDR_DATA_W':'32', 'DDR_ADDR_W':'30'}, 
-        'AES-KU040-DB-G':{'BAUD':'115200', 'FREQ':'100000000', 'DDR_DATA_W':'32', 'DDR_ADDR_W':'30'},
+        'CYCLONEV-GT-DK':{'BAUD':'115200', 'FREQ':'50000000', 'MEM_NO_READ_ON_WRITE':'1', 'DDR_DATA_W':'32', 'DDR_ADDR_W':'30', 'MEM_ADDR_W':'24'}, 
+        'AES-KU040-DB-G':{'BAUD':'115200', 'FREQ':'100000000', 'DDR_DATA_W':'32', 'DDR_ADDR_W':'30', 'MEM_ADDR_W':'24'},
         'DE10-LITE':{'BAUD':'115200', 'FREQ':'50000000'},
         'BASYS3':{'BAUD':'115200', 'FREQ':'100000000'},
-        'SIMULATION':{'BAUD':'3000000', 'FREQ':'100000000', 'DDR_DATA_W':'32', 'DDR_ADDR_W':'24'},
+        'SIMULATION':{'BAUD':'3000000', 'FREQ':'100000000', 'DDR_DATA_W':'32', 'DDR_ADDR_W':'24', 'MEM_ADDR_W':'24'},
         }
 
     # Set config based on value of BOARD variable

--- a/scripts/mkregs.py
+++ b/scripts/mkregs.py
@@ -29,11 +29,15 @@ class mkregs:
 
     @staticmethod
     def verilog_max(a,b):
-        if(a==b): return f"{a}"
-        elif(type(a)==int and type(b)==int): 
-            if (a>b): return f"{a}"
-            else: return f"{b}"
-        else: return f"((({a}) > ({b})) ? ({a}) : ({b}))"
+        if(a==b): return a
+        try:
+            #Assume a and b are int
+            a=int(a)
+            b=int(b)
+            return a if a>b else b
+        except ValueError:
+            #a or b is a string
+            return f"((({a}) > ({b})) ? ({a}) : ({b}))"
 
     def get_reg_table(self, regs, no_overlap):
         # Create reg table
@@ -59,16 +63,17 @@ class mkregs:
     # Generate symbolic expression string to caluclate addr_w in verilog
     @staticmethod
     def calc_verilog_addr_w(log2n_items, n_bytes):
-        if log2n_items == 0 :
+        n_bytes = int(n_bytes)
+        try:
+            #Assume log2n_items is int
+            log2n_items=int(log2n_items)
+            return log2n_items+log(n_bytes,2)
+        except ValueError:
+            #log2n_items is a string
             if n_bytes == 1 :
-                return f"0"
+                return log2n_items
             else :
-                return f"$clog2({int(n_bytes)})"
-        else :
-            if n_bytes == 1 :
-                return f"{log2n_items}"
-            else :
-                return f"{log2n_items}+$clog2({int(n_bytes)})"
+                return f"{log2n_items}+{log(n_bytes,2)}"
             
 
 

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -113,13 +113,15 @@ def setup( python_module, no_overlap=False, peripheral_ios=True, internal_wires=
     #
     # Generate sw
     #
-    if regs:
-        if os.path.isdir(python_module.setup_dir+'/software/esrc'):
+    if os.path.isdir(python_module.build_dir+'/software'): 
+        os.makedirs(python_module.build_dir+'/software/esrc', exist_ok=True)
+        os.makedirs(python_module.build_dir+'/software/psrc', exist_ok=True)
+        if regs:
             mkregs_obj.write_swheader(reg_table, python_module.build_dir+'/software/esrc', top)
             mkregs_obj.write_swcode(reg_table, python_module.build_dir+'/software/esrc', top)
-        if os.path.isdir(python_module.setup_dir+'/software/psrc'): mkregs_obj.write_swheader(reg_table, python_module.build_dir+'/software/psrc', top)
-    if os.path.isdir(python_module.setup_dir+'/software/esrc'): mk_conf.conf_h(confs, top, python_module.build_dir+'/software/esrc')
-    if os.path.isdir(python_module.setup_dir+'/software/psrc'): mk_conf.conf_h(confs, top, python_module.build_dir+'/software/psrc')
+            mkregs_obj.write_swheader(reg_table, python_module.build_dir+'/software/psrc', top)
+        mk_conf.conf_h(confs, top, python_module.build_dir+'/software/esrc')
+        mk_conf.conf_h(confs, top, python_module.build_dir+'/software/psrc')
 
     #
     # Generate TeX

--- a/scripts/submodule_utils.py
+++ b/scripts/submodule_utils.py
@@ -68,19 +68,22 @@ reserved_signals = \
 }
 
 # Import the <corename>_setup.py from the given core directory
-def import_setup(setup_dir):
+def import_setup(module_dir, **kwargs):
     #Find <corename>_setup.py file
-    for x in os.listdir(setup_dir):
+    for x in os.listdir(module_dir):
         if x.endswith("_setup.py"):
             filename = x
             break
     if 'filename' not in vars():
-        raise FileNotFoundError(f"Could not find a *_setup.py file in {setup_dir}")
+        raise FileNotFoundError(f"Could not find a *_setup.py file in {module_dir}")
     #Import <corename>_setup.py
     module_name = filename.split('.')[0]
-    spec = importlib.util.spec_from_file_location(module_name, setup_dir+"/"+filename)
+    spec = importlib.util.spec_from_file_location(module_name, module_dir+"/"+filename)
     module = importlib.util.module_from_spec(spec)
     sys.modules[module_name]=module
+    # Define objects given in the module
+    for key, value in kwargs.items():
+        vars(module)[key]=value
     spec.loader.exec_module(module)
 
     return module

--- a/setup.mk
+++ b/setup.mk
@@ -5,6 +5,7 @@
 
 SHELL=bash
 export
+unexport SETUP_ARGS
 
 SETUP_PYTHON_FILENAME=$(wildcard *_setup.py)
 


### PR DESCRIPTION
- Clean 'sopc_altera_pll*' folders generated in home directory. Related to issue IObundle/iob-soc#519
- Fixed `riscv-gnu-toolchain.nix`. This toolchain now compiles correctly in Nix sandbox environment.
- Update import_setup() function to allow setting arbitrary variables before executing imported module.
- Update software generation in `setup.py`. Now, the `esrc` and `psrc` folders will be built even if they don't exist in the setup dir.
- Prevent exporting SETUP_ARGS. This way recursive calls to makefile won't append to existing SETUP_ARGS list.
- Update 'int' variable type detection in functions of mkregs.py
- Rename iob-soc pragmas. Related to issue IObundle#430