### PR TITLE
feat(revert): Revert commit bfd895f9: Remove verilator --timing

### DIFF
--- a/hardware/simulation/verilator.mk
+++ b/hardware/simulation/verilator.mk
@@ -2,7 +2,6 @@ VTOP?=$(NAME)
 
 VFLAGS+=--cc --exe -I. -I../src -Isrc --top-module $(VTOP)
 VFLAGS+=-Wno-lint
-VFLAGS+=--timing
 # Include embedded headers
 VFLAGS+=-CFLAGS "-I../../../software/esrc"
 # Include bsp.h


### PR DESCRIPTION
- Remove verilator --timing flag, as it is not working as intended. Verilator still throws errors with this flag when running a module with the `IOB_CLOCK` macro. Removing this flag also allows using older versions of Verilator.