### PR TITLE
Fix `GRAB_CMD` command in fpga/Makefile.

### DIFF
--- a/hardware/fpga/Makefile
+++ b/hardware/fpga/Makefile
@@ -62,7 +62,7 @@ endif
 
 #console start command
 CONSOLE_CMD=$(PYTHON_DIR)/console.py -s /dev/usb-uart
-GRAB_CMD=$(PYTHON_DIR)/board_client.py grab $(USER)
+GRAB_CMD=while $(PYTHON_DIR)/board_client.py grab $(USER) | grep "busy" --color=never; do sleep 10; done
 RELEASE_CMD=$(PYTHON_DIR)/board_client.py release $(USER)
 
 #run fpga image

--- a/hardware/fpga/vivado/build.mk
+++ b/hardware/fpga/vivado/build.mk
@@ -26,7 +26,7 @@ export RDI_VERBOSE = False
 VIVADO_FLAGS= -nojournal -log reports/vivado.log -mode batch -source vivado/build.tcl -tclargs $(FPGA_TOP) $(BOARD) "$(VSRC)" "$(DEFINES)" "$(IP)" $(IS_FPGA) $(USE_EXTMEM)
 
 $(FPGA_OBJ): $(VSRC) $(VHDR) $(IP) $(wildcard $(BOARD)/*.sdc)
-	$(FPGA_ENV) && $(VIVADOPATH)/bin/vivado $(VIVADO_FLAGS) 
+	mkdir -p reports && $(FPGA_ENV) && $(VIVADOPATH)/bin/vivado $(VIVADO_FLAGS) 
 
 vivado-clean:
 	@rm -rf .Xil

--- a/hardware/fpga/vivado/build.tcl
+++ b/hardware/fpga/vivado/build.tcl
@@ -72,7 +72,6 @@ report_clock_interaction
 report_cdc -details
 report_bus_skew
 
-file mkdir reports
 report_clocks -file reports/$NAME\_$PART\_clocks.rpt
 report_clock_interaction -file reports/$NAME\_$PART\_clock_interaction.rpt
 report_cdc -details -file reports/$NAME\_$PART\_cdc.rpt


### PR DESCRIPTION
- The `GRAB_CMD` command in the hardware/fpga/Makefile would only print a message and would not wait if a board was busy. 
  This commit adds a loop to wait while the board is busy, trying again every 10 seconds.
- Create reports folder before running vivado.