### PR TITLE
fix(board server): prevent user overwrite

### DIFF
--- a/scripts/board_server.py
+++ b/scripts/board_server.py
@@ -39,7 +39,7 @@ with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
                     response = 'grabbed'
                     timer = time.time()
                 else:
-                    response = 'Board is busy; please wait.'
+                    response = 'Board is busy; try again later.'
                 conn.sendall(response.encode())
             elif data.startswith('release'):
                 released_user_name = data.split()[1]

--- a/scripts/board_server.py
+++ b/scripts/board_server.py
@@ -32,9 +32,10 @@ with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
                     response = f'{board_status} {user_name}'
                 conn.sendall(response.encode())
             elif data.startswith('grab'):
-                user_name = data.split()[1]
+                grabbed_user_name = data.split()[1]
                 if board_status == 'idle':
                     board_status = 'grabbed'
+                    user_name = grabbed_user_name
                     response = 'grabbed'
                     timer = time.time()
                 else:


### PR DESCRIPTION
- fix board server to prevent user_name overwrite in grabbed state.
- Now, `user_name` is only set if grab request is accepted
- Example scenario: 
0. server is idle
1. `./board_client grab userA` // User A grabs board, status = grabbed
2. `./board_client grab userB` // User B tries to grab board, request is denied, but `user_name` is set to `userB`!
3. `./board_client release userA` // User A tries to release board, but since `user_name` does not match `released_user_name`, the request is denied
- update board busy message to reflect correct server expectations: the
client should make a new grab request at a later time