### PR TITLE
Compare with "Test passed!" string instead of using `test.expected` file

### DIFF
--- a/hardware/fpga/Makefile
+++ b/hardware/fpga/Makefile
@@ -99,7 +99,7 @@ endif
 
 test: debug $(TEST_LIST)
 ifeq ($(IS_FPGA),)
-	diff test.log test.expected
+	test "$$(cat test.log)" = "Test passed!"
 endif
 
 debug:

--- a/hardware/simulation/Makefile
+++ b/hardware/simulation/Makefile
@@ -118,7 +118,7 @@ else
 endif
 
 run-tests: $(TEST_LIST)
-	diff test.log test.expected
+	test "$$(cat test.log)" = "Test passed!"
 
 gen-clean:
 	@rm -f *.hex

--- a/software/pc-emul/Makefile
+++ b/software/pc-emul/Makefile
@@ -37,8 +37,8 @@ build: bsp.h fw_emul
 
 run: build
 	@rm -f soc2cnsl cnsl2soc
-	$(CONSOLE_CMD) $(TEST_LOG) &
-	bash -c "trap 'make kill-cnsl &> /dev/null' INT TERM KILL EXIT; ./fw_emul $(TEST_LOG)"
+	$(CONSOLE_CMD) &
+	bash -c "trap 'make kill-cnsl &> /dev/null' INT TERM KILL EXIT; ./fw_emul"
 
 
 # Create bsp.h based on bsp.vh of simulation
@@ -47,7 +47,7 @@ bsp.h:
 	sed -i 's/`/#/' $@
 
 test: clean $(TEST_LIST)
-	diff test.log test.expected
+	test "$$(cat test.log)" = "Test passed!"
 
 # TODO add to iob-soc custom clean list
 # CLEAN_LIST+=kill-cnsl


### PR DESCRIPTION
- Modify `test` targets in makefile segments to compare the `test.log` file contents with the string `Test passed!`. If it matches, then the test was successful, otherwise it throws an error. The `test.expected` files are no longer used.