### PR TITLE
Board scripts: improve USER handling and grab timeout

### DIFF
--- a/scripts/board_client.py
+++ b/scripts/board_client.py
@@ -8,18 +8,26 @@ import os
 HOST = 'localhost'  # Use the loopback interface
 PORT = 50007  # Use the same port as the server
 
+# Check the command line arguments before making connection
+if len(sys.argv) < 2:
+    print('Usage: client.py <query|grab|release> [timeout (seconds)]')
+    sys.exit()
+
+request = sys.argv[1]
+user = os.environ['USER']
+timeout = ''
+try:
+    timeout = sys.argv[2] # only used for grab
+except IndexError:
+    timeout = ''
+
 # Send the request to the server
 with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
     s.connect((HOST, PORT))
-    if len(sys.argv) < 2:
-        print('Usage: client.py <query|grab|release>')
-        sys.exit()
-    request = sys.argv[1]
-    user = os.environ['USER']
-    if request == 'grab' and len(sys.argv) >= 3:
-        request += ' ' + user
-    elif request == 'release' and len(sys.argv) >= 3:
-        request += ' ' + user
+    if request == 'grab':
+        request += f'{request} {user} {timeout}'
+    elif request == 'release':
+        request += f'{request} {user}'
     s.sendall(request.encode())
     data = s.recv(1024)
     print("Board "+data.decode())

--- a/scripts/board_client.py
+++ b/scripts/board_client.py
@@ -2,6 +2,7 @@
 
 import sys
 import socket
+import os
 
 # Define the server's IP and port
 HOST = 'localhost'  # Use the loopback interface
@@ -11,13 +12,14 @@ PORT = 50007  # Use the same port as the server
 with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
     s.connect((HOST, PORT))
     if len(sys.argv) < 2:
-        print('Usage: client.py <query|grab|release> [username]')
+        print('Usage: client.py <query|grab|release>')
         sys.exit()
     request = sys.argv[1]
+    user = os.environ['USER']
     if request == 'grab' and len(sys.argv) >= 3:
-        request += ' ' + sys.argv[2]
+        request += ' ' + user
     elif request == 'release' and len(sys.argv) >= 3:
-        request += ' ' + sys.argv[2]
+        request += ' ' + user
     s.sendall(request.encode())
     data = s.recv(1024)
     print("Board "+data.decode())

--- a/scripts/board_server.py
+++ b/scripts/board_server.py
@@ -32,23 +32,29 @@ with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
                     response = f'{board_status} {user_name}'
                 conn.sendall(response.encode())
             elif data.startswith('grab'):
-                grabbed_user_name = data.split()[1]
-                if board_status == 'idle':
-                    board_status = 'grabbed'
-                    user_name = grabbed_user_name
-                    response = 'grabbed'
-                    timer = time.time()
-                else:
-                    response = 'Board is busy; try again later.'
+                try:
+                    grabbed_user_name = data.split()[1]
+                    if board_status == 'idle':
+                        board_status = 'grabbed'
+                        user_name = grabbed_user_name
+                        response = 'grabbed'
+                        timer = time.time()
+                    else:
+                        response = 'Board is busy; try again later.'
+                except IndexError:
+                    response = 'missing username'
                 conn.sendall(response.encode())
             elif data.startswith('release'):
-                released_user_name = data.split()[1]
-                if released_user_name == user_name:
-                    board_status = 'idle'
-                    user_name = ''
-                    response = 'released'
-                else:
-                    response = 'Access denied'
+                try:
+                    released_user_name = data.split()[1]
+                    if released_user_name == user_name:
+                        board_status = 'idle'
+                        user_name = ''
+                        response = 'released'
+                    else:
+                        response = 'Access denied'
+                except IndexError:
+                    response = 'missing username'
                 conn.sendall(response.encode())
             if time.time() - timer >= 300:
                 board_status = 'idle'


### PR DESCRIPTION
- update board_client to set `USER` from environment. This stops any user
from releasing or grabing the board using another username
- update board_server to check for existing username value in received
message. Send `missing username` message as response.
- add optional `timeout` when grabbing board (set in seconds)
- improve grab timeout accounting in board_server:
    - check for timeout every second (accept and recv operations timeout
    every 1 second, each server loop iteration checks for grab timeout)
    - by default `grab_timeout` is 300, like previous version

**NOTE: update `board_server` deployments after accepting this PR**