### PR TITLE
Upgrade `board_client.py` to replace Makefile handling and `trap` commands.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ ifeq ($(LINT_SERVER),)
 else
 	ssh $(LINT_SSH_FLAGS) $(LINT_USER)@$(LINT_SERVER) "if [ ! -d $(REMOTE_BUILD_DIR) ]; then mkdir -p $(REMOTE_BUILD_DIR); fi"
 	rsync -avz --delete --exclude .git $(LINT_SYNC_FLAGS) . $(LINT_USER)@$(LINT_SERVER):$(REMOTE_BUILD_DIR)
-	ssh $(LINT_SSH_FLAGS) $(LINT_USER)@$(LINT_SERVER) 'make -C $(REMOTE_BUILD_DIR) lint-run MODULE=$(MODULE)'
+	ssh -t $(LINT_SSH_FLAGS) $(LINT_USER)@$(LINT_SERVER) 'make -C $(REMOTE_BUILD_DIR) lint-run MODULE=$(MODULE)'
 	mkdir -p spyglass_reports
 	scp $(LINT_SCP_FLAGS) $(LINT_USER)@$(LINT_SERVER):$(REMOTE_SRC_DIR)/spyglass/consolidated_reports/$(MODULE)_lint_lint_rtl/*.rpt spyglass_reports/.
 endif

--- a/hardware/fpga/Makefile
+++ b/hardware/fpga/Makefile
@@ -5,10 +5,6 @@ SHELL:=bash
 
 include ../../config_build.mk
 
-ifneq ($(wildcard ../../console.mk),)
-include ../../console.mk
-endif
-
 #include local fpga build segment
 ifneq ($(wildcard fpga_build.mk),)
 include fpga_build.mk
@@ -64,31 +60,21 @@ endif
 #console start command
 CONSOLE_START_CMD=$(PYTHON_DIR)/console.py -s /dev/usb-uart
 
-#board client commands
-BOARD_GRAB_CMD=board_client.py grab 300
-BOARD_RELEASE_CMD=board_client.py release
+#board client command
+BOARD_GRAB_CMD=../../scripts/board_client.py grab 300
 
 #run fpga image
 run: build $(RUN_DEPS)
 ifneq ($(NORUN),1)
 ifeq ($(BOARD_SERVER),)
 	cp $(EMB_DIR)/$(NAME)_firmware.bin .
-	bash -c "trap 'make release &> /dev/null' INT TERM KILL EXIT; $(BOARD_GRAB_CMD); $(FPGA_PROG); $(CONSOLE_START_CMD);"
+	$(BOARD_GRAB_CMD) -p '$(FPGA_PROG)' -c '$(CONSOLE_START_CMD)'
 else
 	ssh $(BOARD_USER)@$(BOARD_SERVER) "if [ ! -d $(REMOTE_BUILD_DIR) ]; then mkdir -p $(REMOTE_BUILD_DIR); fi"
 	rsync $(BOARD_SYNC_FLAGS) -avz --delete --force ../.. $(BOARD_USER)@$(BOARD_SERVER):$(REMOTE_BUILD_DIR)
-	bash -c "trap 'make release &> /dev/null' INT TERM KILL; ssh $(BOARD_USER)@$(BOARD_SERVER) 'make -C $(REMOTE_FPGA_DIR) $@ BOARD=$(BOARD) $(UFLAGS)'"
+	ssh $(BOARD_USER)@$(BOARD_SERVER) 'make -C $(REMOTE_FPGA_DIR) $@ BOARD=$(BOARD) $(UFLAGS)'
 	scp $(BOARD_USER)@$(BOARD_SERVER):$(REMOTE_FPGA_DIR)/*.log . 2> /dev/null | true
 endif
-endif
-
-# release the board
-release:
-ifeq ($(BOARD_SERVER),)
-	make kill-cnsl
-	$(BOARD_RELEASE_CMD)
-else
-	ssh $(BOARD_USER)@$(BOARD_SERVER) 'make -C $(REMOTE_FPGA_DIR) $@ BOARD=$(BOARD)'
 endif
 
 # clean

--- a/hardware/fpga/Makefile
+++ b/hardware/fpga/Makefile
@@ -49,7 +49,7 @@ ifeq ($(FPGA_SERVER),)
 else 
 	ssh $(FPGA_SSH_FLAGS) $(FPGA_USER)@$(FPGA_SERVER) "if [ ! -d $(REMOTE_BUILD_DIR) ]; then mkdir -p $(REMOTE_BUILD_DIR); fi"
 	rsync $(FPGA_SYNC_FLAGS) -avz --delete --force ../.. $(FPGA_USER)@$(FPGA_SERVER):$(REMOTE_BUILD_DIR)
-	ssh $(FPGA_SSH_FLAGS) $(FPGA_USER)@$(FPGA_SERVER) 'make -C $(REMOTE_FPGA_DIR) $@ BOARD=$(BOARD) $(UFLAGS)'
+	ssh -t $(FPGA_SSH_FLAGS) $(FPGA_USER)@$(FPGA_SERVER) 'make -C $(REMOTE_FPGA_DIR) $@ BOARD=$(BOARD) $(UFLAGS)'
 	scp $(FPGA_SCP_FLAGS) $(FPGA_USER)@$(FPGA_SERVER):$(REMOTE_FPGA_DIR)/$(FPGA_OBJ) .
 	scp -r $(FPGA_SCP_FLAGS) $(FPGA_USER)@$(FPGA_SERVER):$(REMOTE_FPGA_DIR)/reports .
 ifneq ($(FPGA_STUB),)
@@ -72,7 +72,7 @@ ifeq ($(BOARD_SERVER),)
 else
 	ssh $(BOARD_USER)@$(BOARD_SERVER) "if [ ! -d $(REMOTE_BUILD_DIR) ]; then mkdir -p $(REMOTE_BUILD_DIR); fi"
 	rsync $(BOARD_SYNC_FLAGS) -avz --delete --force ../.. $(BOARD_USER)@$(BOARD_SERVER):$(REMOTE_BUILD_DIR)
-	ssh $(BOARD_USER)@$(BOARD_SERVER) 'make -C $(REMOTE_FPGA_DIR) $@ BOARD=$(BOARD) $(UFLAGS)'
+	ssh -t $(BOARD_USER)@$(BOARD_SERVER) 'make -C $(REMOTE_FPGA_DIR) $@ BOARD=$(BOARD) $(UFLAGS)'
 	scp $(BOARD_USER)@$(BOARD_SERVER):$(REMOTE_FPGA_DIR)/*.log . 2> /dev/null | true
 endif
 endif

--- a/hardware/fpga/quartus/build.mk
+++ b/hardware/fpga/quartus/build.mk
@@ -34,7 +34,7 @@ else
 endif
 
 # Set the Quartus command to porgram the FPGA
-FPGA_PROG=$(FPGA_ENV) quartus_pgm -m jtag -c 1 -o 'p;$(FPGA_TOP).sof'
+FPGA_PROG=$(FPGA_ENV) quartus_pgm -m jtag -c 1 -o "p;$(FPGA_TOP).sof"
 
 QUARTUS_FLAGS = -t quartus/build.tcl $(FPGA_TOP) $(BOARD) "$(VSRC)" "$(IP) " $(IS_FPGA) $(USE_EXTMEM) $(QUARTUS_SEED) $(USE_QUARTUS_PRO)
 

--- a/hardware/lint/alint.mk
+++ b/hardware/lint/alint.mk
@@ -19,7 +19,7 @@ endif
 else
 	ssh $(LINT_SSH_FLAGS) $(LINT_USER)@$(LINT_SERVER) "if [ ! -d $(REMOTE_BUILD_DIR) ]; then mkdir -p $(REMOTE_BUILD_DIR); fi"
 	rsync -avz --delete --exclude .git $(LINT_SYNC_FLAGS) ../.. $(LINT_USER)@$(LINT_SERVER):$(REMOTE_BUILD_DIR)
-	ssh $(LINT_SSH_FLAGS) $(LINT_USER)@$(LINT_SERVER) 'make -C $(REMOTE_LINT_DIR) run LINTER=$(LINTER)'
+	ssh -t $(LINT_SSH_FLAGS) $(LINT_USER)@$(LINT_SERVER) 'make -C $(REMOTE_LINT_DIR) run LINTER=$(LINTER)'
 	mkdir -p alint_reports
 	scp $(LINT_SCP_FLAGS) $(LINT_USER)@$(LINT_SERVER):$(REMOTE_LINT_DIR)/alint_violations* alint_reports/.
 endif

--- a/hardware/lint/spyglass.mk
+++ b/hardware/lint/spyglass.mk
@@ -15,7 +15,7 @@ ifeq ($(LINT_SERVER),)
 else
 	ssh $(LINT_SSH_FLAGS) $(LINT_USER)@$(LINT_SERVER) "if [ ! -d $(REMOTE_BUILD_DIR) ]; then mkdir -p $(REMOTE_BUILD_DIR); fi"
 	rsync -avz --delete --exclude .git $(LINT_SYNC_FLAGS) ../.. $(LINT_USER)@$(LINT_SERVER):$(REMOTE_BUILD_DIR)
-	ssh $(LINT_SSH_FLAGS) $(LINT_USER)@$(LINT_SERVER) 'make -C $(REMOTE_LINT_DIR) run LINTER=$(LINTER)'
+	ssh -t $(LINT_SSH_FLAGS) $(LINT_USER)@$(LINT_SERVER) 'make -C $(REMOTE_LINT_DIR) run LINTER=$(LINTER)'
 	mkdir -p spyglass_reports
 	scp $(LINT_SCP_FLAGS) $(LINT_USER)@$(LINT_SERVER):$(REMOTE_LINT_DIR)/spyglass/consolidated_reports/$(NAME)_lint_lint_rtl/*.rpt spyglass_reports/.
 endif

--- a/hardware/simulation/Makefile
+++ b/hardware/simulation/Makefile
@@ -61,15 +61,18 @@ else
 	ssh $(SIM_SSH_FLAGS) $(SIM_USER)@$(SIM_SERVER) 'make -C $(REMOTE_SIM_DIR) $@ SIMULATOR=$(SIMULATOR) $(UFLAGS)'
 endif
 
+#board client command
+BOARD_GRAB_CMD=../../scripts/board_client.py grab 300
+
 run: remote_build_dir
 ifeq ($(SIM_SERVER),)
 ifneq ($(CONSOLE_CMD),)
-	@rm -f soc2cnsl cnsl2soc
-	$(CONSOLE_CMD) &
-endif
-	bash -c "trap 'make -s kill-sim' INT TERM KILL EXIT; make exec"
+	$(BOARD_GRAB_CMD) -s 'make exec' -c '$(CONSOLE_CMD)'
 else
-	bash -c "trap 'make -s kill-remote-sim' INT TERM KILL; ssh $(SIM_SSH_FLAGS) $(SIM_USER)@$(SIM_SERVER) 'make -C $(REMOTE_SIM_DIR) $@ SIMULATOR=$(SIMULATOR) $(UFLAGS)'"
+	$(BOARD_GRAB_CMD) -s 'make exec'
+endif
+else
+	ssh $(SIM_SSH_FLAGS) $(SIM_USER)@$(SIM_SERVER) 'make -C $(REMOTE_SIM_DIR) $@ SIMULATOR=$(SIMULATOR) $(UFLAGS)'
 ifeq ($(VCD),1)
 	sleep 1 && sync && scp $(SIM_SCP_FLAGS) $(SIM_USER)@$(SIM_SERVER):$(REMOTE_SIM_DIR)/*.vcd .
 endif
@@ -91,26 +94,12 @@ fix-vcd:
 	@tail -n 1 $(VCD_FILE) | wc -c | xargs -I {} truncate $(VCD_FILE) -s -{}
 	@echo "" >> $(VCD_FILE)
 
-kill-sim:
-	@if [ "`pgrep -a -u $$UID | grep console | grep python3 | grep -v grep`" ]; then \
-	kill -9 $$(pgrep -a -u $$UID | grep console | grep python3 | grep -v grep | sed 's/ .*//'); fi
-	@if [ -e *.vcd ]; then make fix-vcd; fi
-
-kill-remote-sim:
-	@echo "INFO: Remote simulator $(SIMULATOR) will be killed"
-	ssh $(SIM_SSH_FLAGS) $(SIM_USER)@$(SIM_SERVER) 'killall -q -u $(SIM_USER) -9 $(SIM_PROC); \
-	make -C $(REMOTE_SIM_DIR) kill-sim'
-ifeq ($(VCD),1)
-	sleep 1 && sync && scp $(SIM_SCP_FLAGS) $(SIM_USER)@$(SIM_SERVER):$(REMOTE_SIM_DIR)/*.vcd .
-	make waves
-endif
-
 # ssh's remote server to run all tests; otherwise, it takes a lot of time to ssh for each individual test
 test: very-clean clean-test-log
 ifneq ($(SIM_SERVER),)
 	ssh $(SIM_SSH_FLAGS) $(SIM_USER)@$(SIM_SERVER) "if [ ! -d $(REMOTE_BUILD_DIR) ]; then mkdir -p $(REMOTE_BUILD_DIR); fi"
 	rsync $(SIM_SYNC_FLAGS) -avz --force --delete ../.. $(SIM_USER)@$(SIM_SERVER):$(REMOTE_BUILD_DIR)
-	bash -c "trap 'make -s kill-remote-sim' INT TERM KILL; ssh $(SIM_SSH_FLAGS) $(SIM_USER)@$(SIM_SERVER) 'make -C $(REMOTE_SIM_DIR) run-tests SIMULATOR=$(SIMULATOR) $(UFLAGS)'"
+	ssh $(SIM_SSH_FLAGS) $(SIM_USER)@$(SIM_SERVER) 'make -C $(REMOTE_SIM_DIR) run-tests SIMULATOR=$(SIMULATOR) $(UFLAGS)'
 	sleep 1 && sync && scp $(SIM_SCP_FLAGS) $(SIM_USER)@$(SIM_SERVER):$(REMOTE_SIM_DIR)/*.log .
 ifeq ($(COV),1)
 	sleep 1 && sync && scp -r $(SIM_SCP_FLAGS) $(SIM_USER)@$(SIM_SERVER):$(REMOTE_SIM_DIR)/cov_work .
@@ -118,7 +107,7 @@ ifeq ($(COV),1)
 	sleep 1 && sync && scp $(SIM_SCP_FLAGS) $(SIM_USER)@$(SIM_SERVER):$(REMOTE_SIM_DIR)/coverage_report_detail.rpt .
 endif
 else
-	bash -c "trap 'make -s kill-sim' INT TERM KILL EXIT; make run-tests"
+	make run-tests
 endif
 
 run-tests: $(TEST_LIST)
@@ -143,4 +132,4 @@ debug:
 
 .PRECIOUS: uut.vcd
 
-.PHONY: build run remote_build_dir waves fix-vcd kill-sim kill-remote-sim test run-tests gen-clean clean-test-log debug
+.PHONY: build run remote_build_dir waves fix-vcd test run-tests gen-clean clean-test-log debug

--- a/hardware/simulation/Makefile
+++ b/hardware/simulation/Makefile
@@ -122,7 +122,7 @@ else
 endif
 
 run-tests: $(TEST_LIST)
-	diff test.log test.expected
+	test "$$(cat test.log)" = "Test passed!"
 
 gen-clean:
 	@rm -f *.hex

--- a/hardware/simulation/Makefile
+++ b/hardware/simulation/Makefile
@@ -58,7 +58,7 @@ build: $(VHDR) $(VSRC) $(HEX) remote_build_dir
 ifeq ($(SIM_SERVER),)
 	make comp
 else
-	ssh $(SIM_SSH_FLAGS) $(SIM_USER)@$(SIM_SERVER) 'make -C $(REMOTE_SIM_DIR) $@ SIMULATOR=$(SIMULATOR) $(UFLAGS)'
+	ssh -t $(SIM_SSH_FLAGS) $(SIM_USER)@$(SIM_SERVER) 'make -C $(REMOTE_SIM_DIR) $@ SIMULATOR=$(SIMULATOR) $(UFLAGS)'
 endif
 
 #board client command
@@ -66,13 +66,9 @@ BOARD_GRAB_CMD=../../scripts/board_client.py grab 300
 
 run: remote_build_dir
 ifeq ($(SIM_SERVER),)
-ifneq ($(CONSOLE_CMD),)
 	$(BOARD_GRAB_CMD) -s 'make exec' -c '$(CONSOLE_CMD)'
 else
-	$(BOARD_GRAB_CMD) -s 'make exec'
-endif
-else
-	ssh $(SIM_SSH_FLAGS) $(SIM_USER)@$(SIM_SERVER) 'make -C $(REMOTE_SIM_DIR) $@ SIMULATOR=$(SIMULATOR) $(UFLAGS)'
+	ssh -t $(SIM_SSH_FLAGS) $(SIM_USER)@$(SIM_SERVER) 'make -C $(REMOTE_SIM_DIR) $@ SIMULATOR=$(SIMULATOR) $(UFLAGS)'
 ifeq ($(VCD),1)
 	sleep 1 && sync && scp $(SIM_SCP_FLAGS) $(SIM_USER)@$(SIM_SERVER):$(REMOTE_SIM_DIR)/*.vcd .
 endif
@@ -99,7 +95,7 @@ test: very-clean clean-test-log
 ifneq ($(SIM_SERVER),)
 	ssh $(SIM_SSH_FLAGS) $(SIM_USER)@$(SIM_SERVER) "if [ ! -d $(REMOTE_BUILD_DIR) ]; then mkdir -p $(REMOTE_BUILD_DIR); fi"
 	rsync $(SIM_SYNC_FLAGS) -avz --force --delete ../.. $(SIM_USER)@$(SIM_SERVER):$(REMOTE_BUILD_DIR)
-	ssh $(SIM_SSH_FLAGS) $(SIM_USER)@$(SIM_SERVER) 'make -C $(REMOTE_SIM_DIR) run-tests SIMULATOR=$(SIMULATOR) $(UFLAGS)'
+	ssh -t $(SIM_SSH_FLAGS) $(SIM_USER)@$(SIM_SERVER) 'make -C $(REMOTE_SIM_DIR) run-tests SIMULATOR=$(SIMULATOR) $(UFLAGS)'
 	sleep 1 && sync && scp $(SIM_SCP_FLAGS) $(SIM_USER)@$(SIM_SERVER):$(REMOTE_SIM_DIR)/*.log .
 ifeq ($(COV),1)
 	sleep 1 && sync && scp -r $(SIM_SCP_FLAGS) $(SIM_USER)@$(SIM_SERVER):$(REMOTE_SIM_DIR)/cov_work .
@@ -117,7 +113,7 @@ gen-clean:
 	@rm -f *.hex
 	@find . -maxdepth 1 -name "*.vh" -not \( -name "bsp.vh" -o -name "uut_build.mk" \) -delete
 ifneq ($(SIM_SERVER),)
-	ssh $(SIM_SSH_FLAGS) $(SIM_USER)@$(SIM_SERVER) 'if [ -f $(REMOTE_SIM_DIR)/Makefile ]; then make -C $(REMOTE_SIM_DIR) $@; fi'
+	ssh -t $(SIM_SSH_FLAGS) $(SIM_USER)@$(SIM_SERVER) 'if [ -f $(REMOTE_SIM_DIR)/Makefile ]; then make -C $(REMOTE_SIM_DIR) $@; fi'
 endif
 
 clean-test-log:

--- a/hardware/simulation/verilator.mk
+++ b/hardware/simulation/verilator.mk
@@ -2,6 +2,7 @@ VTOP?=$(NAME)
 
 VFLAGS+=--cc --exe -I. -I../src -Isrc --top-module $(VTOP)
 VFLAGS+=-Wno-lint
+VFLAGS+=--timing
 # Include embedded headers
 VFLAGS+=-CFLAGS "-I../../../software/src -I../../../software"
 

--- a/hardware/syn/Makefile
+++ b/hardware/syn/Makefile
@@ -46,7 +46,7 @@ ifeq ($(SYN_SERVER),)
 else
 	ssh $(SYN_SSH_FLAGS) $(SYN_USER)@$(SYN_SERVER) 'if [ ! -d $(REMOTE_BUILD_DIR) ]; then mkdir -p $(REMOTE_BUILD_DIR); fi'
 	rsync $(SYN_SYNC_FLAGS) -avz --force --delete ../.. $(SYN_USER)@$(SYN_SERVER):$(REMOTE_BUILD_DIR)
-	ssh $(SYN_SSH_FLAGS) -Y -C $(SYN_USER)@$(SYN_SERVER) 'make -C $(REMOTE_SYN_DIR) $@ NODE=$(NODE) $(UFLAGS)'
+	ssh -t $(SYN_SSH_FLAGS) -Y -C $(SYN_USER)@$(SYN_SERVER) 'make -C $(REMOTE_SYN_DIR) $@ NODE=$(NODE) $(UFLAGS)'
 	scp $(SYN_SCP_FLAGS) $(SYN_USER)@$(SYN_SERVER):$(REMOTE_SYN_DIR)/*.log .
 	scp $(SYN_SCP_FLAGS) $(SYN_USER)@$(SYN_SERVER):$(REMOTE_SYN_DIR)/$(OUTPUT_DIR)/*.rpt .
 	scp $(SYN_SCP_FLAGS) $(SYN_USER)@$(SYN_SERVER):$(REMOTE_SYN_DIR)/$(OUTPUT_DIR)/*.v .

--- a/scripts/black_format.py
+++ b/scripts/black_format.py
@@ -5,7 +5,6 @@ import subprocess
 
 
 if __name__ == "__main__":
-
     parser = argparse.ArgumentParser(
         prog="black_format",
         description="""Python Black format script.

--- a/scripts/blocks.py
+++ b/scripts/blocks.py
@@ -6,6 +6,7 @@
 from latex import write_table
 from submodule_utils import get_peripherals
 
+
 # Generate blocks.tex file with list TeX tables of blocks (Verilog modules)
 def generate_blocks_list_tex(blocks, out_dir):
     blocks_file = open(f"{out_dir}/blocks.tex", "w")

--- a/scripts/board_client.py
+++ b/scripts/board_client.py
@@ -6,6 +6,20 @@ import sys
 import socket
 import os
 import time
+import subprocess
+import signal
+import iob_colors
+#import ctypes
+
+# Tell system to send a SIGTERM signal to this process if the parent process os killed
+# This is needed to ensure this program is killed on remote machines when the parent `sshd` process also terminates.
+# Define constants for prctl options and signals
+#PR_SET_PDEATHSIG = 1
+#SIGTERM = 15
+## Load the libc library
+#libc = ctypes.CDLL("libc.so.6")
+## Call prctl with PR_SET_PDEATHSIG and SIGTERM
+#libc.prctl(PR_SET_PDEATHSIG, SIGTERM)
 
 # Define the client's IP, port and version
 # Must match the server's
@@ -19,8 +33,8 @@ DURATION = "15"  # Default duration is 5 seconds
 
 
 def perror():
-    n = len(sys.argv)
-    print(f"Usage: client.py [grab [duration in seconds] | release] {n}")
+    print(f"Usage: client.py [grab [duration in seconds] -c [console launch command] [-p [fpga program command] | -s [simulator run command]] | release]")
+    print("If -p is given then -c is required. If -s is given then -c is optional.")
     sys.exit(1)
 
 
@@ -36,51 +50,138 @@ if command == "grab":
             DURATION = int(sys.argv[2])
         except ValueError:
             perror()
-    if len(sys.argv) > 3:
-        perror()
 elif command != "release" and command != "query":
     perror()
 
-# Form the request
-request = ""
-if command == "grab":
-    request += f"{command} {USER} {DURATION} {VERSION}"
-elif command == "release":
-    request += f"{command} {USER} {VERSION}"
-elif command == "query":
-    request += f"{command} {VERSION}"
+# Console run command is only required with -p
+console_command=None
+if "-c" in sys.argv:
+    console_command = sys.argv[sys.argv.index("-c")+1]
 
+# FPGA program command is optional
+fpga_prog_command=None
+if "-p" in sys.argv:
+    fpga_prog_command = sys.argv[sys.argv.index("-p")+1]
+
+# Simulator run command is optional
+simulator_run_command=None
+if "-s" in sys.argv:
+    simulator_run_command = sys.argv[sys.argv.index("-s")+1]
+
+# Ensure either -p or -s is given with grab command
+assert command != "grab" or bool(fpga_prog_command) != bool(simulator_run_command), "Either -p or -s must be present with 'grab' command. (Cannot be both)"
+
+# Ensure -c is given with -p
+assert not fpga_prog_command or console_command, "-c must be present with -p"
+
+# Function to form the request
+def form_request(command):
+    request = ""
+    if command == "grab":
+        request += f"{command} {USER} {DURATION} {VERSION}"
+    elif command == "release":
+        request += f"{command} {USER} {VERSION}"
+    elif command == "query":
+        request += f"{command} {VERSION}"
+    return request
+
+request = form_request(command)
 if DEBUG:
-    print(f'DEBUG: Request is "{request}"')
+    print(f'{iob_colors.OKBLUE}DEBUG: Request is "{request}"{iob_colors.ENDC}')
 
+# Function to send the request
+def send_request(request):
+    while True:
+        # Create a socket
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.settimeout(10)
 
-while True:
-    # Create a socket
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    s.settimeout(10)
+        # Connect with the server
+        try:
+            s.connect((HOST, PORT))
+        except:
+            print(f"{iob_colors.FAIL}Could not connect to server{iob_colors.ENDC}")
+            sys.exit(1)
 
-    # Connect with the server
-    try:
-        s.connect((HOST, PORT))
-    except:
-        print("Could not connect to server")
-        sys.exit(1)
+        # Send the request to the server
+        s.sendall(request.encode("utf-8"))
 
-    # Send the request to the server
-    s.sendall(request.encode("utf-8"))
-
-    # Receive the response from the server
-    response = s.recv(1024).decode()
-    print(response)
-
-    # Process the response
-    if "ERROR" in response:
-        sys.exit(1)
-
-    if "grab" in request and "Failure" in response:
-        time_remaining = float(response.split(" ")[-2])
-        print("Trying again in", time_remaining, "seconds")
+        # Receive the response from the server
+        response = s.recv(1024).decode()
         s.close()
-        time.sleep(time_remaining)
+        print(response)
+
+        # Process the response
+        if "ERROR" in response:
+            sys.exit(1)
+
+        if "grab" in request and "Failure" in response:
+            time_remaining = float(response.split(" ")[-2])
+            print(f"{iob_colors.WARNING}Trying again in", time_remaining, f"seconds{iob_colors.ENDC}")
+            time.sleep(time_remaining)
+        else:
+            break
+
+# Function to release the board
+def release_board(signal=None, frame=None):
+    request = form_request("release")
+    send_request(request)
+
+# If we will grab the FPGA board (-p was given), then ensure we release it when terminating board_client
+if command == "grab" and fpga_prog_command:
+    signal.signal(signal.SIGINT, release_board)
+    signal.signal(signal.SIGTERM, release_board)
+
+# Connect to server if command is not "grab", or if the -p argument was given
+if command != "grab" or fpga_prog_command:
+    send_request(request)
+
+# End program if command is not "grab"
+if command != "grab": sys.exit(0)
+# Lines below will only run if command=="grab" and request successful
+
+# Launch simulator in parallel if -s was given
+sim_proc=None
+if simulator_run_command:
+    print(f'{iob_colors.INFO}Running simulator{iob_colors.ENDC}')
+    sim_proc = subprocess.Popen(simulator_run_command, stdout=sys.stdout, stderr=sys.stderr, shell=True)
+
+    def kill_simulator(signal=None, frame=None):
+        print(f'{iob_colors.INFO}Killing simulator{iob_colors.ENDC}')
+        # Debug write to file
+        #with open("simulator_kill.txt", "w") as f:
+        #    f.write("killed")
+        sim_proc.terminate()
+    signal.signal(signal.SIGINT, kill_simulator)
+    signal.signal(signal.SIGTERM, kill_simulator)
+
+exit_code=0
+try:
+    start_time = time.time()
+    # Program the FPGA if -p is given
+    if fpga_prog_command:
+        print(f'{iob_colors.INFO}Programming FPGA{iob_colors.ENDC}')
+        subprocess.run(fpga_prog_command, stdout=sys.stdout, stderr=sys.stderr, shell=True, timeout=DURATION)
+    remaining_duration = int(DURATION) - (time.time()-start_time)
+
+    # Run the console
+    if console_command:
+        print(f'{iob_colors.INFO}Running console{iob_colors.ENDC}')
+        subprocess.run(console_command, stdout=sys.stdout, stderr=sys.stderr, shell=True, timeout=remaining_duration)
     else:
-        sys.exit(0)
+        print(f'{iob_colors.INFO}Waiting for simulator to finish{iob_colors.ENDC}')
+        sim_proc.wait(timeout=remaining_duration)
+
+except subprocess.TimeoutExpired:
+    print(f'{iob_colors.FAIL}Board grab duration expired!{iob_colors.ENDC}')
+    exit_code=1
+    # Kill the simulator if -s was given and console timed out
+    if simulator_run_command: kill_simulator()
+
+# Release the board if -p is given
+if fpga_prog_command:
+    release_board()
+
+sys.exit(exit_code)
+
+#TODO: Check if parent process is sshd. If parent process changes, terminate the program (it means sshd stopped).

--- a/scripts/board_client.py
+++ b/scripts/board_client.py
@@ -25,7 +25,7 @@ import iob_colors
 # Must match the server's
 HOST = "localhost"  # Use the loopback interface
 PORT = 50007  # Use the same port as the server
-VERSION = "V0.1"
+VERSION = "V0.2"
 
 # user and duration board is needed
 USER = os.environ["USER"]

--- a/scripts/board_client.py
+++ b/scripts/board_client.py
@@ -9,17 +9,18 @@ import time
 import subprocess
 import signal
 import iob_colors
-#import ctypes
+
+# import ctypes
 
 # Tell system to send a SIGTERM signal to this process if the parent process os killed
 # This is needed to ensure this program is killed on remote machines when the parent `sshd` process also terminates.
 # Define constants for prctl options and signals
-#PR_SET_PDEATHSIG = 1
-#SIGTERM = 15
+# PR_SET_PDEATHSIG = 1
+# SIGTERM = 15
 ## Load the libc library
-#libc = ctypes.CDLL("libc.so.6")
+# libc = ctypes.CDLL("libc.so.6")
 ## Call prctl with PR_SET_PDEATHSIG and SIGTERM
-#libc.prctl(PR_SET_PDEATHSIG, SIGTERM)
+# libc.prctl(PR_SET_PDEATHSIG, SIGTERM)
 
 # Define the client's IP, port and version
 # Must match the server's
@@ -33,7 +34,9 @@ DURATION = "15"  # Default duration is 5 seconds
 
 
 def perror():
-    print(f"Usage: client.py [grab [duration in seconds] -c [console launch command] [-p [fpga program command] | -s [simulator run command]] | release]")
+    print(
+        f"Usage: client.py [grab [duration in seconds] -c [console launch command] [-p [fpga program command] | -s [simulator run command]] | release]"
+    )
     print("If -p is given then -c is required. If -s is given then -c is optional.")
     sys.exit(1)
 
@@ -54,25 +57,28 @@ elif command != "release" and command != "query":
     perror()
 
 # Console run command is only required with -p
-console_command=None
+console_command = None
 if "-c" in sys.argv:
-    console_command = sys.argv[sys.argv.index("-c")+1]
+    console_command = sys.argv[sys.argv.index("-c") + 1]
 
 # FPGA program command is optional
-fpga_prog_command=None
+fpga_prog_command = None
 if "-p" in sys.argv:
-    fpga_prog_command = sys.argv[sys.argv.index("-p")+1]
+    fpga_prog_command = sys.argv[sys.argv.index("-p") + 1]
 
 # Simulator run command is optional
-simulator_run_command=None
+simulator_run_command = None
 if "-s" in sys.argv:
-    simulator_run_command = sys.argv[sys.argv.index("-s")+1]
+    simulator_run_command = sys.argv[sys.argv.index("-s") + 1]
 
 # Ensure either -p or -s is given with grab command
-assert command != "grab" or bool(fpga_prog_command) != bool(simulator_run_command), "Either -p or -s must be present with 'grab' command. (Cannot be both)"
+assert command != "grab" or bool(fpga_prog_command) != bool(
+    simulator_run_command
+), "Either -p or -s must be present with 'grab' command. (Cannot be both)"
 
 # Ensure -c is given with -p
 assert not fpga_prog_command or console_command, "-c must be present with -p"
+
 
 # Function to form the request
 def form_request(command):
@@ -85,9 +91,11 @@ def form_request(command):
         request += f"{command} {VERSION}"
     return request
 
+
 request = form_request(command)
 if DEBUG:
     print(f'{iob_colors.OKBLUE}DEBUG: Request is "{request}"{iob_colors.ENDC}')
+
 
 # Function to send the request
 def send_request(request):
@@ -117,15 +125,21 @@ def send_request(request):
 
         if "grab" in request and "Failure" in response:
             time_remaining = float(response.split(" ")[-2])
-            print(f"{iob_colors.WARNING}Trying again in", time_remaining, f"seconds{iob_colors.ENDC}")
+            print(
+                f"{iob_colors.WARNING}Trying again in",
+                time_remaining,
+                f"seconds{iob_colors.ENDC}",
+            )
             time.sleep(time_remaining)
         else:
             break
+
 
 # Function to release the board
 def release_board(signal=None, frame=None):
     request = form_request("release")
     send_request(request)
+
 
 # If we will grab the FPGA board (-p was given), then ensure we release it when terminating board_client
 if command == "grab" and fpga_prog_command:
@@ -137,8 +151,10 @@ if command != "grab" or fpga_prog_command:
     send_request(request)
 
 # End program if command is not "grab"
-if command != "grab": sys.exit(0)
+if command != "grab":
+    sys.exit(0)
 # Lines below will only run if command=="grab" and request successful
+
 
 def exit_program(exit_code):
     # Release the board if -p is given
@@ -150,6 +166,8 @@ def exit_program(exit_code):
 
 # List of processes to kill when terminating board_client
 proc_list = []
+
+
 # Function to kill all processes from proc_list and exit with error.
 def kill_processes(sig=None, frame=None):
     for proc in proc_list:
@@ -163,16 +181,24 @@ def kill_processes(sig=None, frame=None):
             os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
     exit_program(1)
 
+
 signal.signal(signal.SIGINT, kill_processes)
 signal.signal(signal.SIGTERM, kill_processes)
 
 # Launch simulator in parallel if -s was given
-sim_proc=None
+sim_proc = None
 if simulator_run_command:
-    print(f'{iob_colors.INFO}Running simulator{iob_colors.ENDC}')
-    sim_proc = subprocess.Popen(simulator_run_command, stdout=sys.stdout, stderr=sys.stderr, shell=True, start_new_session=True)
+    print(f"{iob_colors.INFO}Running simulator{iob_colors.ENDC}")
+    sim_proc = subprocess.Popen(
+        simulator_run_command,
+        stdout=sys.stdout,
+        stderr=sys.stderr,
+        shell=True,
+        start_new_session=True,
+    )
     # Add the simulator process to the list of processes to kill
     proc_list.append(sim_proc)
+
 
 # Function to wait for a process to finish
 # If the process times out, kill all other processes
@@ -180,34 +206,47 @@ def proc_wait(proc, timeout):
     try:
         proc.wait(timeout=timeout)
     except subprocess.TimeoutExpired:
-        print(f'{iob_colors.FAIL}Board grab duration expired!{iob_colors.ENDC}')
+        print(f"{iob_colors.FAIL}Board grab duration expired!{iob_colors.ENDC}")
         kill_processes()
+
 
 # Start counting time since start of FPGA programming
 start_time = time.time()
 
 # Program the FPGA if -p is given
 if fpga_prog_command:
-    print(f'{iob_colors.INFO}Programming FPGA{iob_colors.ENDC}')
-    fpga_prog_proc = subprocess.Popen(fpga_prog_command, stdout=sys.stdout, stderr=sys.stderr, shell=True, start_new_session=True)
+    print(f"{iob_colors.INFO}Programming FPGA{iob_colors.ENDC}")
+    fpga_prog_proc = subprocess.Popen(
+        fpga_prog_command,
+        stdout=sys.stdout,
+        stderr=sys.stderr,
+        shell=True,
+        start_new_session=True,
+    )
     proc_list.append(fpga_prog_proc)
     proc_wait(fpga_prog_proc, DURATION)
 
 # Update time passed
-remaining_duration = int(DURATION) - (time.time()-start_time)
+remaining_duration = int(DURATION) - (time.time() - start_time)
 
 # Choose whether to run console or just wait for simulator to finish
 if console_command:
     # Run console and wait for completion/timeout.
-    print(f'{iob_colors.INFO}Running console{iob_colors.ENDC}')
-    console_proc = subprocess.Popen(console_command, stdout=sys.stdout, stderr=sys.stderr, shell=True, start_new_session=True)
+    print(f"{iob_colors.INFO}Running console{iob_colors.ENDC}")
+    console_proc = subprocess.Popen(
+        console_command,
+        stdout=sys.stdout,
+        stderr=sys.stderr,
+        shell=True,
+        start_new_session=True,
+    )
     proc_list.append(console_proc)
     proc_wait(console_proc, remaining_duration)
 
     # Update time passed
-    remaining_duration = int(DURATION) - (time.time()-remaining_duration)
+    remaining_duration = int(DURATION) - (time.time() - remaining_duration)
 
-print(f'{iob_colors.INFO}Waiting for simulator to finish{iob_colors.ENDC}')
+print(f"{iob_colors.INFO}Waiting for simulator to finish{iob_colors.ENDC}")
 proc_wait(sim_proc, remaining_duration)
 
 exit_program(0)

--- a/scripts/board_server.py
+++ b/scripts/board_server.py
@@ -99,7 +99,6 @@ s.listen()
 
 # Loop forever
 while True:
-
     conn, addr = s.accept()
     request = conn.recv(1024).decode("utf-8")
     if DEBUG:

--- a/scripts/board_server.py
+++ b/scripts/board_server.py
@@ -23,7 +23,7 @@ import socket
 
 HOST = "localhost"  # Listen on all available interfaces
 PORT = 50007  # Use a non-privileged port
-VERSION = "V0.1"
+VERSION = "V0.2"
 
 # user and duration board is needed
 USER = ""

--- a/scripts/build_srcs.py
+++ b/scripts/build_srcs.py
@@ -394,24 +394,24 @@ def sw_setup(python_module):
         # Copy LIB software Makefile
         shutil.copy(f"{LIB_DIR}/software/Makefile", f"{build_dir}/software")
 
-        # Create 'scripts/' directory and console.mk
+        # Create 'scripts/' directory
         python_setup(build_dir)
-        shutil.copy(f"{LIB_DIR}/scripts/console.mk", f"{build_dir}/console.mk")
 
 
 def python_setup(build_dir):
-    sim_srcs = [
+    scripts = [
         "sw_defines.py",
         "hw_defines.py",
         "console.py",
         "hex_split.py",
         "makehex.py",
         "board_client.py",
+        "iob_colors.py",
     ]
     dest_dir = f"{build_dir}/scripts"
     if not os.path.exists(dest_dir):
         os.mkdir(dest_dir)
-    copy_files(LIB_DIR, dest_dir, sim_srcs, "*.py")
+    copy_files(LIB_DIR, dest_dir, scripts, "*.py")
 
 
 def doc_setup(python_module):

--- a/scripts/build_srcs.py
+++ b/scripts/build_srcs.py
@@ -13,6 +13,7 @@ import mk_configuration as mk_conf
 
 LIB_DIR = "submodules/LIB"
 
+
 # Copy a file if destination does not exist
 def copy_without_override(src, dst):
     if not os.path.isfile(dst):

--- a/scripts/clang_format.py
+++ b/scripts/clang_format.py
@@ -5,7 +5,6 @@ import subprocess
 
 
 if __name__ == "__main__":
-
     parser = argparse.ArgumentParser(
         prog="clang_format",
         description="""Clang format script.

--- a/scripts/clang_install.py
+++ b/scripts/clang_install.py
@@ -8,7 +8,6 @@ import sys
 LLVM_VERSION = "15"
 
 if __name__ == "__main__":
-
     parser = argparse.ArgumentParser(
         prog="clang_install",
         description="""Install clang tools.

--- a/scripts/console.mk
+++ b/scripts/console.mk
@@ -1,4 +1,0 @@
-CNSL_PID:=ps aux | grep $(USER) | grep console | grep python3 | grep -v grep
-kill-cnsl:
-	@if [ "`$(CNSL_PID)`" ]; then \
-	kill -9 $$($(CNSL_PID) | awk '{print $$2}'); fi

--- a/scripts/console.py
+++ b/scripts/console.py
@@ -268,8 +268,8 @@ def init_console():
             time.sleep(2)
             ser.port = sys.argv[sys.argv.index("-s") + 1]
             ser.open()
-            ser.flushInput()
-            ser.flushOutput()
+            ser.reset_input_buffer()
+            ser.reset_output_buffer()
         except Exception:
             cnsl_perror("Error open serial port.")
     else:

--- a/scripts/if_gen.py
+++ b/scripts/if_gen.py
@@ -912,6 +912,7 @@ def suffix(direction):
 # Port
 #
 
+
 # Write port with given direction, bus width, name and description to file
 def write_port(direction, width, name, description, fout):
     fout.write(direction + width + name + ", //" + description + "\n")
@@ -950,6 +951,7 @@ def s_port(prefix, fout, bus_size=1):
 #
 # Portmap
 #
+
 
 # Write portmap with given port, connection name, width, bus start, bus size and description to file
 def write_portmap(port, connection_name, width, bus_start, bus_size, description, fout):
@@ -1051,6 +1053,7 @@ def s_s_portmap(port_prefix, wire_prefix, fout, bus_start=0, bus_size=1):
 #
 # Wire
 #
+
 
 # Write wire with given name, bus size, width and description to file
 def write_wire(name, bus_size, width, description, fout):
@@ -1268,6 +1271,7 @@ def create_signal_table(interface_name):
 # Write to .vh file
 #
 
+
 # port_prefix: Prefix for ports in a portmap file.
 # wire_prefix: Prefix for wires in a portmap file; Prefix for wires in a `*wires.vh` file; Prefix for ports in a `*port.vh` file (these ports also create wires);
 def write_vh_contents(
@@ -1297,7 +1301,6 @@ def write_vh_contents(
 
 
 def main():
-
     args = parse_arguments()
 
     # bus type

--- a/scripts/joinHexFiles.py
+++ b/scripts/joinHexFiles.py
@@ -19,6 +19,7 @@ if os.path.isfile(argv[2]):
 else:
     file2_contents = []
 
+
 # Trim lines of zeros from end of file
 def trimEndingZeros(data):
     data_size = len(data)

--- a/scripts/mkregs.py
+++ b/scripts/mkregs.py
@@ -9,6 +9,7 @@ from latex import write_table
 from submodule_utils import eval_param_expression_from_config
 import re
 
+
 # Use a class for the entire module, as it may be imported multiple times, but must have instance variables (multiple cores/submodules have different registers)
 class mkregs:
     def __init__(self):
@@ -233,7 +234,6 @@ class mkregs:
         f.write(f"\t.iob_rvalid_nxt_o(iob_rvalid_nxt),\n")
 
     def write_hwcode(self, table, out_dir, top):
-
         #
         # SWREG INSTANCE
         #

--- a/scripts/submodule_utils.py
+++ b/scripts/submodule_utils.py
@@ -67,6 +67,7 @@ reserved_signals = {
     "axi_rready_o": ".axi_rready_o      (axi_rready_o  [1-1:0])",
 }
 
+
 # Import the <corename>_setup.py from the given core directory
 def import_setup(module_dir, **kwargs):
     # Find <corename>_setup.py file
@@ -315,7 +316,6 @@ def eval_param_expression(param_expression, params_dict):
 # confs: list of dictionaries, each of which describes a parameter and has attributes: 'name', 'val' and 'max'.
 # param_attribute: name of the attribute in the paramater that contains the value to replace in string given. Attribute names are: 'val', 'min, or 'max'.
 def eval_param_expression_from_config(param_expression, confs, param_attribute):
-
     # Create parameter dictionary with correct values to be replaced in string
     params_dict = {}
     for param in confs:

--- a/scripts/verilog2tex.py
+++ b/scripts/verilog2tex.py
@@ -19,7 +19,6 @@ Parse top-level parameters and macros
 
 
 def param_parse(topv, param_defaults, defines):
-
     param_defaults.update(defines)
 
     params = []
@@ -108,7 +107,6 @@ Parse block diagram modules
 
 
 def block_parse(block):
-
     b_list = []
 
     for line in block:
@@ -133,7 +131,6 @@ def block_parse(block):
 
 
 def io_parse(io_lines, params, defines):
-
     table_found = 0
     table_name = ""
     table = []
@@ -200,7 +197,6 @@ def io_parse(io_lines, params, defines):
 
 
 def swreg_parse(pregs):
-
     table = []
     for i in range(len(pregs)):
         table.append(pregs[i]["regs"])
@@ -249,7 +245,6 @@ def header_parse(vh, defines):
 
 
 def verilog2tex(pregs, top, vh, v):
-
     # macro dictionary
     defines = {}
 

--- a/software/Makefile
+++ b/software/Makefile
@@ -31,14 +31,10 @@ INCLUDES ?=-I. -Isrc
 #         PC emulation settings         #
 #########################################
 
-ifneq ($(wildcard ../console.mk),)
-include ../console.mk
-endif
-
 # compiler flags
 EMUL_CFLAGS=-Os -std=gnu99 -Wl,--strip-debug
 
-CONSOLE_CMD=../scripts/console.py -L
+CONSOLE_CMD=rm -f soc2cnsl cnsl2soc; ../scripts/console.py -L
 
 EMUL_INCLUDES=-I. -Isrc
 
@@ -87,10 +83,11 @@ fw_emul: $(EMUL_HDR) $(EMUL_SRC)
 build_emul: fw_emul
 	@echo "build"
 
+#board client command
+BOARD_GRAB_CMD=../scripts/board_client.py grab 300
+
 run_emul: build_emul
-	@rm -f soc2cnsl cnsl2soc
-	$(CONSOLE_CMD) &
-	bash -c "trap 'make kill-cnsl &> /dev/null' INT TERM KILL EXIT; ./fw_emul"
+	$(BOARD_GRAB_CMD) -s './fw_emul' -c '$(CONSOLE_CMD)'
 
 test_emul: clean $(EMUL_TEST_LIST)
 	test "$$(cat test.log)" = "Test passed!"
@@ -102,7 +99,7 @@ test_emul: clean $(EMUL_TEST_LIST)
 #########################################
 
 # TODO add to iob-soc custom clean list
-# CLEAN_LIST+=kill-cnsl
+# CLEAN_LIST+=
 
 clean: $(CLEAN_LIST)
 	@rm -rf *.bin *.elf *.map *.hex


### PR DESCRIPTION
**Note**: This PR upgrades the `board_client.py` and `board_server.py` to the version `0.2`. Only the  `board_client.py` has changes, but the communication protocol is the same. The version of the `board_server.py` was only upgraded to prevent version mismatch errors with the new `board_client.py`. The new `board_server.py` should be installed on the machines that share FPGA boards.

The FPGA checks in https://github.com/IObundle/iob-soc/pull/546 have not yet passed, as the new `board_server.py` has not been installed in those machines. Once installed, the FPGA checks should pass.

**Changelog**
- Re-add verilator `--timing` flag as it is required for opencryptolinux. This reverts commit 56eabd0.
- Remove diff with `test.expected` file and instead compare with `Test passed!` string.
  - This change is a partial revert of commit 3a676f5.
  - The commit 3a676f5 had re-added the diff with the `test.expected` file without implementing the same change in the `fpga/Makefile` and `pc-emul/Makefile`. It also did not provide an explanation for this change.
  - By reverting that commit, we use the `Test passed!` string that was originally implemented in the commit b9d2ea4.
- Modified `board_client.py` to handle the: fpga programming; simulator; pc-emulation; and console processes.
  - It now handles interrupt signals and closes the respective processes.
  - It keeps running while the board is grabbed.
  - It has a new timeout feature. If the processes that it handles exceed the timeout, it stops them.
  - It also runs in simulation and pc-emul, it controls the simulator and console processes. In these modes of operation, it does not connect to the `board_server.py`.
  - It has a list of active processes and kills them if it receives an interrupt, timeout, or if they finish.
  - Upgrade `board_client.py` version from `0.1` to `0.2`. This change is due to significant modifications to this program in this PR. Note that there are no changes related to the communication protocol with the board server. Therefore, this version is compatible with the current server implementation (`board_server.py` version 0.1) even though it would give a version mismatch error.
- Upgrade `board_server.py` version from `0.1` to `0.2`. There are no changes in the `board_server.py` contents, however this change is needed to match the new `board_client.py` version.
 - Add `-t` flag to some ssh connections that may require interrupting the remote process or sending signals to it. The `-t` flag forces pseudo-terminal allocation, forwarding every signal received to the remote process.
