### PR TITLE
Copy `.vcd` file from remote machines; Update `board_client.py` and `submodule_utils.py`; Update `clean` target.

### DIFF
--- a/hardware/simulation/Makefile
+++ b/hardware/simulation/Makefile
@@ -73,9 +73,11 @@ else
 	make exec
 endif
 else
-	ssh -t $(SIM_SSH_FLAGS) $(SIM_USER)@$(SIM_SERVER) 'make -C $(REMOTE_SIM_DIR) $@ SIMULATOR=$(SIMULATOR) $(UFLAGS)'
 ifeq ($(VCD),1)
-	sleep 1 && sync && scp $(SIM_SCP_FLAGS) $(SIM_USER)@$(SIM_SERVER):$(REMOTE_SIM_DIR)/*.vcd .
+	trap 'scp $(SIM_SCP_FLAGS) $(SIM_USER)@$(SIM_SERVER):$(REMOTE_SIM_DIR)/*.vcd .' INT TERM EXIT;\
+	ssh -t $(SIM_SSH_FLAGS) $(SIM_USER)@$(SIM_SERVER) 'make -C $(REMOTE_SIM_DIR) $@ SIMULATOR=$(SIMULATOR) $(UFLAGS)' || true
+else
+	ssh -t $(SIM_SSH_FLAGS) $(SIM_USER)@$(SIM_SERVER) 'make -C $(REMOTE_SIM_DIR) $@ SIMULATOR=$(SIMULATOR) $(UFLAGS)'
 endif
 ifeq ($(COV),1)
 	sleep 1 && sync && scp -r $(SIM_SCP_FLAGS) $(SIM_USER)@$(SIM_SERVER):$(REMOTE_SIM_DIR)/cov_work .

--- a/hardware/simulation/Makefile
+++ b/hardware/simulation/Makefile
@@ -62,7 +62,8 @@ else
 endif
 
 #board client command
-BOARD_GRAB_CMD=../../scripts/board_client.py grab 300
+GRAB_TIMEOUT ?= 300
+BOARD_GRAB_CMD=../../scripts/board_client.py grab $(GRAB_TIMEOUT)
 
 run: remote_build_dir
 ifeq ($(SIM_SERVER),)

--- a/scripts/board_client.py
+++ b/scripts/board_client.py
@@ -267,7 +267,7 @@ if __name__ == "__main__":
         proc_wait(console_proc, remaining_duration)
 
         # Update time passed
-        remaining_duration = int(DURATION) - (time.time() - remaining_duration)
+        remaining_duration = int(DURATION) - (time.time() - start_time)
 
     # Wait for simulator to finish
     if simulator_run_command:

--- a/scripts/board_client.py
+++ b/scripts/board_client.py
@@ -123,7 +123,10 @@ def kill_processes(sig=None, frame=None):
             except subprocess.TimeoutExpired:
                 # Process did not terminate gracefully, kill it
                 os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-    exit_program(1)
+    if sig in [signal.SIGINT, signal.SIGTERM]:
+        exit_program(0)
+    else:
+        exit_program(1)
 
 
 # Function to wait for a process to finish

--- a/scripts/board_client.py
+++ b/scripts/board_client.py
@@ -8,10 +8,13 @@ import subprocess
 import signal
 import argparse
 import importlib.util
+
 if importlib.util.find_spec("iob_colors") is not None:
     import iob_colors
 else:
-    print("Module `iob_colors.py` not found. Please set the `PYTHONPATH` environment variable with the location of this module.")
+    print(
+        "Module `iob_colors.py` not found. Please set the `PYTHONPATH` environment variable with the location of this module."
+    )
     print("For example: `export PYTHONPATH=<Path to iob-lib>/scripts`")
     sys.exit(1)
 

--- a/scripts/board_client.py
+++ b/scripts/board_client.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S python3 -B
 
 import sys
 import socket
@@ -6,8 +6,14 @@ import os
 import time
 import subprocess
 import signal
-import iob_colors
 import argparse
+import importlib.util
+if importlib.util.find_spec("iob_colors") is not None:
+    import iob_colors
+else:
+    print("Module `iob_colors.py` not found. Please set the `PYTHONPATH` environment variable with the location of this module.")
+    print("For example: `export PYTHONPATH=<Path to iob-lib>/scripts`")
+    sys.exit(1)
 
 DEBUG = False
 

--- a/scripts/board_client.py
+++ b/scripts/board_client.py
@@ -123,10 +123,11 @@ def kill_processes(sig=None, frame=None):
             except subprocess.TimeoutExpired:
                 # Process did not terminate gracefully, kill it
                 os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-    if sig in [signal.SIGINT, signal.SIGTERM]:
-        exit_program(0)
-    else:
+    # Dont throw an error if the function is called from signal handler
+    if sig is None:
         exit_program(1)
+    else:
+        exit_program(0)
 
 
 # Function to wait for a process to finish

--- a/scripts/submodule_utils.py
+++ b/scripts/submodule_utils.py
@@ -17,8 +17,6 @@ reserved_signals = {
     "clk_i": ".clk_i(clk_i)",
     "cke_i": ".cke_i(cke_i)",
     "en_i": ".en_i(en_i)",
-    "rst_i": ".rst_i(rst_i)",
-    "reset": ".reset(rst_i)",
     "arst_i": ".arst_i(arst_i)",
     "iob_avalid_i": ".iob_avalid_i(slaves_req[`AVALID(`/*<InstanceName>*/)])",
     "iob_addr_i": ".iob_addr_i(slaves_req[`ADDRESS(`/*<InstanceName>*/,`/*<SwregFilename>*/_ADDR_W)])",

--- a/scripts/submodule_utils.py
+++ b/scripts/submodule_utils.py
@@ -194,7 +194,9 @@ def get_peripheral_ios(peripherals_list, submodules):
             # Import <corename>_setup.py module
             module = import_setup(submodules["dirs"][instance["type"]])
             # Extract only PIO signals from the peripheral (no reserved/known signals)
-            port_list[instance["type"]] = get_pio_signals(get_module_io(module.ios, module.confs, instance["name"]))
+            port_list[instance["type"]] = get_pio_signals(
+                get_module_io(module.ios, module.confs, instance["name"])
+            )
 
     ios_list = []
     # Append ports of each instance
@@ -464,7 +466,9 @@ def get_module_io(ios, confs=None, corename=None):
 
             # Add corename prefix to parameters in port width, if `confs` and `corename` are given
             if confs and corename:
-                signal["n_bits"] = add_prefix_to_parameters_in_port(signal,confs,corename+"_")["n_bits"]
+                signal["n_bits"] = add_prefix_to_parameters_in_port(
+                    signal, confs, corename + "_"
+                )["n_bits"]
         module_signals.extend(table_signals)
     return module_signals
 

--- a/setup.mk
+++ b/setup.mk
@@ -104,7 +104,8 @@ endif
 
 
 clean:
-	@if [ -f $(BUILD_DIR)/Makefile ]; then make -C $(BUILD_DIR) clean; fi && rm -rf $(BUILD_DIR)
+	-@if [ -f $(BUILD_DIR)/Makefile ]; then make -C $(BUILD_DIR) clean; fi
+	@rm -rf $(BUILD_DIR)
 
 # Remove all __pycache__ folders with python bytecode
 python-cache-clean:


### PR DESCRIPTION
- Copy `.vcd` file from remote machine after interrupt signal with `VCD=1`
- Modify `clean` target in `setup.mk` to ignore errors when running `make -C $(BUILD_DIR) clean`. 
  The previous `clean` target would throw errors if the setup function did not run correctly or was incomplete. By ignoring the errors, the incorrectly set-up build directory can still be cleaned (removed).
- Update `board_client.py`:
  - Modify `board_client.py` to exit with code 0 if terminated due to interrupt/terminate signal.
  - Fix timeout bug in `board_client.py`
  - Add an error message in `board_client.py` with instructions to add search path for the `iob_colors.py` module.
- Update `submodule_utils.py`:
  - Remove synchronous reset signals from reserved signals list in `submodule_utils.py`
  - Add option in `get_module_io()` function of `submodule_utils.py` to add a corename prefix to the parameters in port widths of peripheral IOs.