### PR TITLE
Remove `-S` flag from `env` program in `board_client.py`

### DIFF
--- a/scripts/board_client.py
+++ b/scripts/board_client.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S python3 -B
+#!/usr/bin/env python3
 
 import sys
 import socket


### PR DESCRIPTION
Remove `-S` flag from the `env` program in the shebang line. Not every `env` program supports this flag.
This is the implementation of the suggestion I left in https://github.com/IObundle/iob-lib/pull/488.