### PR TITLE
Python format for setup

### DIFF
--- a/setup.mk
+++ b/setup.mk
@@ -38,6 +38,11 @@ BUILD_DOC_DIR = $(BUILD_DIR)/document
 BUILD_FIG_DIR = $(BUILD_DOC_DIR)/figures
 BUILD_TSRC_DIR = $(BUILD_DOC_DIR)/tsrc
 
+format:
+	$(LIB_DIR)/scripts/black_format.py
+
+format-check:
+	$(LIB_DIR)/scripts/black_format.py --check
 
 setup: debug
 
@@ -111,7 +116,7 @@ clean:
 python-cache-clean:
 	find . -name "*__pycache__" -exec rm -rf {} \; -prune
 
-debug: $(BUILD_DIR) $(SRC)
+debug: format-check $(BUILD_DIR) $(SRC)
 	@for i in $(SRC); do echo $$i; done
 
 

--- a/setup.mk
+++ b/setup.mk
@@ -38,7 +38,7 @@ BUILD_DOC_DIR = $(BUILD_DIR)/document
 BUILD_FIG_DIR = $(BUILD_DOC_DIR)/figures
 BUILD_TSRC_DIR = $(BUILD_DOC_DIR)/tsrc
 
-format:
+python-format:
 	$(LIB_DIR)/scripts/black_format.py
 
 format-check:

--- a/setup.mk
+++ b/setup.mk
@@ -44,8 +44,6 @@ python-format:
 python-format-check:
 	$(LIB_DIR)/scripts/black_format.py --check
 
-format-check: python-format-check
-
 setup: debug
 
 $(BUILD_DIR):
@@ -118,7 +116,7 @@ clean:
 python-cache-clean:
 	find . -name "*__pycache__" -exec rm -rf {} \; -prune
 
-debug: format-check $(BUILD_DIR) $(SRC)
+debug: python-format-check $(BUILD_DIR) $(SRC)
 	@for i in $(SRC); do echo $$i; done
 
 

--- a/setup.mk
+++ b/setup.mk
@@ -41,8 +41,10 @@ BUILD_TSRC_DIR = $(BUILD_DOC_DIR)/tsrc
 python-format:
 	$(LIB_DIR)/scripts/black_format.py
 
-format-check:
+python-format-check:
 	$(LIB_DIR)/scripts/black_format.py --check
+
+format-check: python-format-check
 
 setup: debug
 


### PR DESCRIPTION
- add python-format check to setup target
- add python-format target to LIB/setup.mk
- top level can use `make python-format` to format repository code
- currently only supports python
- closes iobundle/iob-lib#494