### PR TITLE
Only replace includes inside Verilog modules; Fix bug; Format Verilog headers.

### DIFF
--- a/scripts/verilog_tools.py
+++ b/scripts/verilog_tools.py
@@ -27,7 +27,9 @@ def replace_includes(search_paths=[]):
 
     # Search contents of the verilog files for `include statements
     for verilog_file in verilog_files:
-        found_module_start = False  # Used to check if we are parsing inside a Verilog module
+        found_module_start = (
+            False  # Used to check if we are parsing inside a Verilog module
+        )
         # print(f"{iob_colors.INFO}Replacing includes in '{verilog_file}'{iob_colors.ENDC}")
         with open(verilog_file, "r") as f:
             lines = f.readlines()
@@ -45,8 +47,13 @@ def replace_includes(search_paths=[]):
             # Check if line starts with `include, ignoring spaces and tabs
             if line.lstrip().startswith("`include"):
                 # Get filename from `include statement
-                filename = line.split("`include")[1].split(
-                    "//")[0].strip().strip('"').strip("'")
+                filename = (
+                    line.split("`include")[1]
+                    .split("//")[0]
+                    .strip()
+                    .strip('"')
+                    .strip("'")
+                )
                 # Don't include duplicates
                 if filename in duplicates:
                     new_lines.append(line)

--- a/scripts/verilog_tools.py
+++ b/scripts/verilog_tools.py
@@ -27,16 +27,26 @@ def replace_includes(search_paths=[]):
 
     # Search contents of the verilog files for `include statements
     for verilog_file in verilog_files:
+        found_module_start = False  # Used to check if we are parsing inside a Verilog module
         # print(f"{iob_colors.INFO}Replacing includes in '{verilog_file}'{iob_colors.ENDC}")
         with open(verilog_file, "r") as f:
             lines = f.readlines()
         new_lines = []
         # Search for lines starting with `include inside the verilog file
         for line in lines:
+            if not found_module_start:
+                # Check if line starts with Verilog module, ignoring spaces and tabs
+                if line.lstrip().startswith("module "):
+                    found_module_start = True
+                # Ignore lines before module start
+                new_lines.append(line)
+                continue
+
             # Check if line starts with `include, ignoring spaces and tabs
             if line.lstrip().startswith("`include"):
                 # Get filename from `include statement
-                filename = line.split("`include")[1].split("//")[0].strip().strip('"').strip("'")
+                filename = line.split("`include")[1].split(
+                    "//")[0].strip().strip('"').strip("'")
                 # Don't include duplicates
                 if filename in duplicates:
                     new_lines.append(line)

--- a/scripts/verilog_tools.py
+++ b/scripts/verilog_tools.py
@@ -36,7 +36,7 @@ def replace_includes(search_paths=[]):
             # Check if line starts with `include, ignoring spaces and tabs
             if line.lstrip().startswith("`include"):
                 # Get filename from `include statement
-                filename = line.split("`include")[1].strip().strip('"').strip("'")
+                filename = line.split("`include")[1].split("//")[0].strip().strip('"').strip("'")
                 # Don't include duplicates
                 if filename in duplicates:
                     new_lines.append(line)

--- a/setup.mk
+++ b/setup.mk
@@ -46,15 +46,15 @@ python-format-check:
 
 verilog-format:
 	# Run formatter on all verilog files of setup directory
-	verible-verilog-format --inplace `find . -name *.v -not -path "*/submodules/*" | tr '\n' ' '`
+	verible-verilog-format --inplace `find . -type f \( -name "*.v" -o -name "*.vh" \) -not -path "*/submodules/*" | tr '\n' ' '`
 	# Run formatter on all verilog files of build directory (includes generated files)
-	#verible-verilog-format --inplace `find $(BUILD_DIR) -name *.v  | tr '\n' ' '`
+	#verible-verilog-format --inplace `find $(BUILD_DIR) -type f \( -name "*.v" -o -name "*.vh" \) | tr '\n' ' '`
 
 verilog-format-check:
 	# Run linter on all verilog files of setup directory
-	verible-verilog-lint `find . -name *.v -not -path "*/submodules/*" | tr '\n' ' '`
+	#verible-verilog-lint `find . -type f \( -name "*.v" -o -name "*.vh" \) -not -path "*/submodules/*" | tr '\n' ' '`
 	# Run linter on all verilog files of build directory (includes generated files)
-	#verible-verilog-lint `find $(BUILD_DIR) -name *.v  | tr '\n' ' '`
+	#verible-verilog-lint `find $(BUILD_DIR) -type f \( -name "*.v" -o -name "*.vh" \) | tr '\n' ' '`
 
 setup: debug
 


### PR DESCRIPTION
- Fix bug replacing includes;
- Format Verilog headers files along with sources;
- Update `verilog_tools.py` to only replace include statements inside the Verilog modules. It no longer replaces the include statements at the start of the file, outside the module. Related to https://github.com/IObundle/iob-lib/issues/491