### PR TITLE
feat(nix): Downgrade `llvmPackages` version to 14.

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -13,6 +13,6 @@ pkgs.mkShell {
     (callPackage ./riscv-gnu-toolchain.nix { })
     verible
     black
-    llvmPackages_15.clangUseLLVM
+    llvmPackages_14.clangUseLLVM
   ];
 }


### PR DESCRIPTION
- By using version 14 instead of 15, we don't need to manually change the Nix configuration to use unstable packages.