### PR TITLE
feat(verilog_tools): Replace includes in Verilog files recursively.

### DIFF
--- a/scripts/verilog_tools.py
+++ b/scripts/verilog_tools.py
@@ -1,6 +1,62 @@
 #!/usr/bin/env python3
 import os
 import iob_colors
+import re
+
+DEBUG = False
+
+# code: list of lines of code
+# files: dictionary of files that can be included
+#        Dictionary format: {filename: path}
+# ignore_files: list of files that should not be included
+
+
+def replace_includes_in_code(code, files, ignore_files=[]):
+    new_lines = []
+    found_module_start = (
+        False  # Used to check if we are parsing inside a Verilog module
+    )
+    # Search for lines starting with `include inside the verilog file
+    for line in code:
+        if not found_module_start:
+            # Check if line starts with Verilog module, ignoring spaces and tabs
+            if line.lstrip().startswith("module ") or re.match('^\s*\S+\s#?\(', line):
+                found_module_start = True
+            # Ignore lines before module start
+            new_lines.append(line)
+            continue
+
+        # Ignore lines that don't start with `include, ignoring spaces and tabs
+        if not line.lstrip().startswith("`include"):
+            new_lines.append(line)
+            continue
+
+        # Get filename from `include statement
+        filename = (
+            line.split("`include")[1]
+            .split("//")[0]
+            .strip()
+            .strip('"')
+            .strip("'")
+        )
+        # Don't include duplicates
+        if filename in ignore_files:
+            new_lines.append(line)
+            continue
+        # Dont include files that don't exist
+        if filename not in files:
+            new_lines.append(line)
+            if DEBUG:
+                print(
+                    f"{iob_colors.WARNING}File '{filename}' not found. Not replacing include.{iob_colors.ENDC}"
+                )
+            continue
+        # Include verilog header contents in the new_lines list
+        with open(files[filename] + "/" + filename, "r") as f:
+            new_lines += replace_includes_in_code(
+                f.readlines(), files, ignore_files)
+    return new_lines
+
 
 # Function to search recursively for every verilog file inside the search_path
 # Find include statements inside those files and replace them by the contents of the included file
@@ -8,68 +64,29 @@ import iob_colors
 
 def replace_includes(search_paths=[]):
     # Search recursively for every verilog file inside the search_path and place them in a list
-    verilog_files = []
-    verilog_header_files = {}
+    verilog_files = {}
     duplicates = []
     for path in search_paths:
         for root, dirs, files in os.walk(path):
             for file in files:
-                if file.endswith(".v") or file.endswith(".sv"):
-                    verilog_files.append(os.path.join(root, file))
-                if file.endswith(".vh"):
-                    if file in verilog_header_files and file not in duplicates:
+                if file.endswith(".v") or file.endswith(".sv") or file.endswith(".vh"):
+                    if file in verilog_files and file not in duplicates:
                         duplicates.append(file)
-                        print(
-                            f"{iob_colors.INFO}Duplicate verilog header file '{file}' found. Will not replace include.{iob_colors.ENDC}"
-                        )
-                    if file not in verilog_header_files:
-                        verilog_header_files[file] = root
+                        if DEBUG:
+                            print(
+                                f"{iob_colors.INFO}Duplicate verilog file '{file}' found. Will not replace include.{iob_colors.ENDC}"
+                            )
+                    if file not in verilog_files:
+                        verilog_files[file] = root
 
     # Search contents of the verilog files for `include statements
-    for verilog_file in verilog_files:
-        found_module_start = (
-            False  # Used to check if we are parsing inside a Verilog module
-        )
-        # print(f"{iob_colors.INFO}Replacing includes in '{verilog_file}'{iob_colors.ENDC}")
-        with open(verilog_file, "r") as f:
+    for filename in verilog_files:
+        # print(f"{iob_colors.INFO}Replacing includes in '{filename}'{iob_colors.ENDC}")
+        with open(verilog_files[filename] + "/" + filename, "r") as f:
             lines = f.readlines()
-        new_lines = []
-        # Search for lines starting with `include inside the verilog file
-        for line in lines:
-            if not found_module_start:
-                # Check if line starts with Verilog module, ignoring spaces and tabs
-                if line.lstrip().startswith("module "):
-                    found_module_start = True
-                # Ignore lines before module start
-                new_lines.append(line)
-                continue
 
-            # Check if line starts with `include, ignoring spaces and tabs
-            if line.lstrip().startswith("`include"):
-                # Get filename from `include statement
-                filename = (
-                    line.split("`include")[1]
-                    .split("//")[0]
-                    .strip()
-                    .strip('"')
-                    .strip("'")
-                )
-                # Don't include duplicates
-                if filename in duplicates:
-                    new_lines.append(line)
-                    continue
-                # Dont include files that don't exist
-                if filename not in verilog_header_files:
-                    new_lines.append(line)
-                    print(
-                        f"{iob_colors.WARNING}File '{filename}' not found. Not replacing include.{iob_colors.ENDC}"
-                    )
-                    continue
-                # Include verilog header contents in the new_lines list
-                with open(verilog_header_files[filename] + "/" + filename, "r") as f:
-                    new_lines += f.readlines()
-            else:
-                new_lines.append(line)
+        new_lines = replace_includes_in_code(lines, verilog_files, duplicates)
+
         # Write new_lines to the file
-        with open(verilog_file, "w") as f:
+        with open(verilog_files[filename] + "/" + filename, "w") as f:
             f.writelines(new_lines)

--- a/scripts/verilog_tools.py
+++ b/scripts/verilog_tools.py
@@ -20,7 +20,7 @@ def replace_includes_in_code(code, files, ignore_files=[]):
     for line in code:
         if not found_module_start:
             # Check if line starts with Verilog module, ignoring spaces and tabs
-            if line.lstrip().startswith("module ") or re.match('^\s*\S+\s#?\(', line):
+            if line.lstrip().startswith("module ") or re.match("^\s*\S+\s#?\(", line):
                 found_module_start = True
             # Ignore lines before module start
             new_lines.append(line)
@@ -33,11 +33,7 @@ def replace_includes_in_code(code, files, ignore_files=[]):
 
         # Get filename from `include statement
         filename = (
-            line.split("`include")[1]
-            .split("//")[0]
-            .strip()
-            .strip('"')
-            .strip("'")
+            line.split("`include")[1].split("//")[0].strip().strip('"').strip("'")
         )
         # Don't include duplicates
         if filename in ignore_files:
@@ -53,8 +49,7 @@ def replace_includes_in_code(code, files, ignore_files=[]):
             continue
         # Include verilog header contents in the new_lines list
         with open(files[filename] + "/" + filename, "r") as f:
-            new_lines += replace_includes_in_code(
-                f.readlines(), files, ignore_files)
+            new_lines += replace_includes_in_code(f.readlines(), files, ignore_files)
     return new_lines
 
 


### PR DESCRIPTION
- Update `replace_includes()` function to replace `include` statements:
  - Recursively;
  - Inside instances of modules as well. Not just inside module definitions.