### PR TITLE
feat(verilog_tools): Replace every `include` from already included files. 

### DIFF
--- a/scripts/verilog_tools.py
+++ b/scripts/verilog_tools.py
@@ -9,18 +9,17 @@ DEBUG = False
 # files: dictionary of files that can be included
 #        Dictionary format: {filename: path}
 # ignore_files: list of files that should not be included
+# replace_all: boolean to replace all includes, even if they are not inside a module
 
 
-def replace_includes_in_code(code, files, ignore_files=[]):
+def replace_includes_in_code(code, files, ignore_files=[], replace_all=False):
     new_lines = []
-    found_module_start = (
-        False  # Used to check if we are parsing inside a Verilog module
-    )
+    found_module_start = replace_all
     # Search for lines starting with `include inside the verilog file
     for line in code:
         if not found_module_start:
             # Check if line starts with Verilog module, ignoring spaces and tabs
-            if line.lstrip().startswith("module ") or re.match("^\s*\S+\s#?\(", line):
+            if line.lstrip().startswith("module "):
                 found_module_start = True
             # Ignore lines before module start
             new_lines.append(line)
@@ -30,6 +29,13 @@ def replace_includes_in_code(code, files, ignore_files=[]):
         if not line.lstrip().startswith("`include"):
             new_lines.append(line)
             continue
+
+        # Ignore lines after module end unless replace_all is True
+        if not replace_all and line.lstrip().startswith("endmodule"):
+            found_module_start = False
+            new_lines.append(line)
+            continue
+
 
         # Get filename from `include statement
         filename = (
@@ -49,7 +55,7 @@ def replace_includes_in_code(code, files, ignore_files=[]):
             continue
         # Include verilog header contents in the new_lines list
         with open(files[filename] + "/" + filename, "r") as f:
-            new_lines += replace_includes_in_code(f.readlines(), files, ignore_files)
+            new_lines += replace_includes_in_code(f.readlines(), files, ignore_files, True)
     return new_lines
 
 
@@ -80,7 +86,7 @@ def replace_includes(search_paths=[]):
         with open(verilog_files[filename] + "/" + filename, "r") as f:
             lines = f.readlines()
 
-        new_lines = replace_includes_in_code(lines, verilog_files, duplicates)
+        new_lines = replace_includes_in_code(lines, verilog_files, duplicates, False)
 
         # Write new_lines to the file
         with open(verilog_files[filename] + "/" + filename, "w") as f:

--- a/scripts/verilog_tools.py
+++ b/scripts/verilog_tools.py
@@ -36,7 +36,6 @@ def replace_includes_in_code(code, files, ignore_files=[], replace_all=False):
             new_lines.append(line)
             continue
 
-
         # Get filename from `include statement
         filename = (
             line.split("`include")[1].split("//")[0].strip().strip('"').strip("'")
@@ -55,7 +54,9 @@ def replace_includes_in_code(code, files, ignore_files=[], replace_all=False):
             continue
         # Include verilog header contents in the new_lines list
         with open(files[filename] + "/" + filename, "r") as f:
-            new_lines += replace_includes_in_code(f.readlines(), files, ignore_files, True)
+            new_lines += replace_includes_in_code(
+                f.readlines(), files, ignore_files, True
+            )
     return new_lines
 
 


### PR DESCRIPTION
- Update `replace_includes_in_code()` function to replace every `include` statement from the contents of files that have already been included.
- Remove parse for Verilog instances.
- Parse for `endmodule` keyword to prevent replacing includes after the module's finish.

When a file is processed by this script and it is not being included into another one, then only the `include` statements that are inside a Verilog module are replaced.
If the file being processed is being included in another one, then every `include` statement of this file will be replaced.