### PR TITLE
[verilog_tools.py] Delete files after including them; Include files with duplicates in build dir.

### DIFF
--- a/hardware/modules/iob_tasks/iob_tasks.vh
+++ b/hardware/modules/iob_tasks/iob_tasks.vh
@@ -1,7 +1,6 @@
 //
 // Tasks for the IOb Native protocol
 //
-`include "iob_utils.vh"
 
 // Write data to IOb Native slave
 task iob_write;

--- a/scripts/verilog_tools.py
+++ b/scripts/verilog_tools.py
@@ -89,7 +89,9 @@ def replace_includes(search_paths=[]):
             with open(filepath + "/" + filename, "r") as f:
                 lines = f.readlines()
 
-            new_lines, _files_included = replace_includes_in_code(lines, verilog_files, False)
+            new_lines, _files_included = replace_includes_in_code(
+                lines, verilog_files, False
+            )
             files_to_delete += _files_included
 
             # Write new_lines to the file

--- a/scripts/verilog_tools.py
+++ b/scripts/verilog_tools.py
@@ -3,17 +3,18 @@ import os
 import iob_colors
 import re
 
-DEBUG = False
+DEBUG = True
 
 # code: list of lines of code
 # files: dictionary of files that can be included
 #        Dictionary format: {filename: path}
-# ignore_files: list of files that should not be included
 # replace_all: boolean to replace all includes, even if they are not inside a module
+# Returns: (list of lines of code with includes replaced, list of files included)
 
 
-def replace_includes_in_code(code, files, ignore_files=[], replace_all=False):
+def replace_includes_in_code(code, files, replace_all=False):
     new_lines = []
+    files_included = []
     found_module_start = replace_all
     # Search for lines starting with `include inside the verilog file
     for line in code:
@@ -40,10 +41,6 @@ def replace_includes_in_code(code, files, ignore_files=[], replace_all=False):
         filename = (
             line.split("`include")[1].split("//")[0].strip().strip('"').strip("'")
         )
-        # Don't include duplicates
-        if filename in ignore_files:
-            new_lines.append(line)
-            continue
         # Dont include files that don't exist
         if filename not in files:
             new_lines.append(line)
@@ -52,12 +49,21 @@ def replace_includes_in_code(code, files, ignore_files=[], replace_all=False):
                     f"{iob_colors.WARNING}File '{filename}' not found. Not replacing include.{iob_colors.ENDC}"
                 )
             continue
+
+        print(f"{iob_colors.INFO}Including file '{filename}'{iob_colors.ENDC}")
         # Include verilog header contents in the new_lines list
-        with open(files[filename] + "/" + filename, "r") as f:
-            new_lines += replace_includes_in_code(
-                f.readlines(), files, ignore_files, True
+        # Note: it will only include the contents of the first file found with this name.
+        with open(files[filename][0] + "/" + filename, "r") as f:
+            _lines, _files_included = replace_includes_in_code(
+                f.readlines(), files, True
             )
-    return new_lines
+            new_lines += _lines
+            files_included += _files_included
+
+        # Add this filename to files_included list
+        files_included.append(filename)
+
+    return new_lines, files_included
 
 
 # Function to search recursively for every verilog file inside the search_path
@@ -65,30 +71,35 @@ def replace_includes_in_code(code, files, ignore_files=[], replace_all=False):
 
 
 def replace_includes(search_paths=[]):
+    files_to_delete = []
     # Search recursively for every verilog file inside the search_path and place them in a list
     verilog_files = {}
-    duplicates = []
     for path in search_paths:
         for root, dirs, files in os.walk(path):
             for file in files:
                 if file.endswith(".v") or file.endswith(".sv") or file.endswith(".vh"):
-                    if file in verilog_files and file not in duplicates:
-                        duplicates.append(file)
-                        if DEBUG:
-                            print(
-                                f"{iob_colors.INFO}Duplicate verilog file '{file}' found. Will not replace include.{iob_colors.ENDC}"
-                            )
                     if file not in verilog_files:
-                        verilog_files[file] = root
+                        verilog_files[file] = []
+                    verilog_files[file].append(root)
 
     # Search contents of the verilog files for `include statements
     for filename in verilog_files:
-        # print(f"{iob_colors.INFO}Replacing includes in '{filename}'{iob_colors.ENDC}")
-        with open(verilog_files[filename] + "/" + filename, "r") as f:
-            lines = f.readlines()
+        for filepath in verilog_files[filename]:
+            # print(f"{iob_colors.INFO}Replacing includes in '{filename}'{iob_colors.ENDC}")
+            with open(filepath + "/" + filename, "r") as f:
+                lines = f.readlines()
 
-        new_lines = replace_includes_in_code(lines, verilog_files, duplicates, False)
+            new_lines, _files_included = replace_includes_in_code(lines, verilog_files, False)
+            files_to_delete += _files_included
 
-        # Write new_lines to the file
-        with open(verilog_files[filename] + "/" + filename, "w") as f:
-            f.writelines(new_lines)
+            # Write new_lines to the file
+            with open(filepath + "/" + filename, "w") as f:
+                f.writelines(new_lines)
+
+    # Remove duplicate files to delete
+    files_to_delete = list(set(files_to_delete))
+
+    # Delete included files
+    for filename in files_to_delete:
+        for filepath in verilog_files[filename]:
+            os.remove(filepath + "/" + filename)


### PR DESCRIPTION
- Delete files after including their contents in all the other files that need them.
- Allow inclusion of duplicate files. 
  Note: This assumes that files included inside modules always have the same contents. If there are multiple files with the same name in the build directory, and they are included inside a Verilog module, then all those files must have the same contents, otherwise errors will occur. The `verilog_tools.py` script will insert the contents of the first file found with this name (it assumes the others with the same name also have the same contents).