### PR TITLE
format some verilog files

### DIFF
--- a/hardware/modules/axis2axi/axis2axi_in.v
+++ b/hardware/modules/axis2axi/axis2axi_in.v
@@ -96,9 +96,9 @@ module axis2axi_in #(
    generate
       if (AXI_ADDR_W >= 13) begin  // 4k boundary can only happen to LEN higher or equal to 13
 
-         wire [     12:0] boundary_transfer_len = (13'h1000 - current_address[11:0]) >> 2;
+         wire [12:0] boundary_transfer_len = (13'h1000 - current_address[11:0]) >> 2;
 
-         reg  [BURST_W:0] boundary_burst_size;
+         reg [BURST_W:0] boundary_burst_size;
          always @* begin
             boundary_burst_size = non_boundary_burst_size;
 

--- a/hardware/modules/axis2axi/axis2axi_out.v
+++ b/hardware/modules/axis2axi/axis2axi_out.v
@@ -57,18 +57,18 @@ module axis2axi_out #(
 
    // Instantiation wires
    wire [AXI_ADDR_W-1:0] current_address, current_length;
-   wire [      1:0] state;
+   wire [1:0] state;
 
    // Logical wires and combinatorial regs
-   wire             doing_global_transfer = (state != 2'h0);
-   wire             doing_local_transfer = (state == 2'h3);
-   wire [     15:0] boundary_transfer_len = (16'h1000 - current_address[11:0]) >> 2;
-   wire             normal_burst_possible = (current_length >= BURST_SIZE);
-   wire             last_burst_possible = (current_length < BURST_SIZE);
+   wire doing_global_transfer = (state != 2'h0);
+   wire doing_local_transfer = (state == 2'h3);
+   wire [15:0] boundary_transfer_len = (16'h1000 - current_address[11:0]) >> 2;
+   wire normal_burst_possible = (current_length >= BURST_SIZE);
+   wire last_burst_possible = (current_length < BURST_SIZE);
 
    wire [BURST_W:0] burst_size;
 
-   reg  [BURST_W:0] non_boundary_burst_size;
+   reg [BURST_W:0] non_boundary_burst_size;
    always @* begin
       non_boundary_burst_size = 0;
 
@@ -81,9 +81,9 @@ module axis2axi_out #(
    generate
       if (AXI_ADDR_W >= 13) begin  // 4k boundary can only happen to LEN higher or equal to 13
 
-         wire [     12:0] boundary_transfer_len = (13'h1000 - current_address[11:0]) >> 2;
+         wire [12:0] boundary_transfer_len = (13'h1000 - current_address[11:0]) >> 2;
 
-         reg  [BURST_W:0] boundary_burst_size;
+         reg [BURST_W:0] boundary_burst_size;
          always @* begin
             boundary_burst_size = non_boundary_burst_size;
 

--- a/hardware/modules/axis2axi/axis2axi_tb.v
+++ b/hardware/modules/axis2axi/axis2axi_tb.v
@@ -163,7 +163,7 @@ module axis2axi_tb;
 
       repeat (10) @(posedge clk) #1;
 
-      $finish;
+      $finish();
    end
 
    task AxiStreamInRun(input [31:0] address, startValue, runLength);
@@ -191,7 +191,7 @@ module axis2axi_tb;
             if (axis_in_data != i) begin
                $display("Error on run from %h to %h, index: %d", address, address + runLength * 4,
                         i);
-               $fatal;
+               $fatal();
             end
 
             @(posedge clk) #1;
@@ -235,7 +235,7 @@ module axis2axi_tb;
             if (delayed_axis_out_valid) begin
                if (axis_out_data != readIndex) begin
                   //$write("Error on run from %h to %h,index: %d",address,address + runLength * 4,readIndex);
-                  //$fatal;
+                  //$fatal();
                end
                readIndex = readIndex + 1;
 `ifdef AXIS_2_AXI_MANUAL_TB

--- a/hardware/modules/counter/iob_modcnt/iob_modcnt.v
+++ b/hardware/modules/counter/iob_modcnt/iob_modcnt.v
@@ -17,8 +17,8 @@ module iob_modcnt #(
     output [DATA_W-1:0] data_o
 );
 
-   wire              ld_count = data_o == mod_i;
-   wire [DATA_W-1:0] ld_vall = {DATA_W{1'b0}};
+   wire ld_count = data_o == mod_i;
+   wire                             [DATA_W-1:0] ld_vall = {DATA_W{1'b0}};
 
    iob_counter_ld #(
        .DATA_W (DATA_W),

--- a/hardware/modules/fifo/iob_fifo_async/iob_fifo_async_tb.v
+++ b/hardware/modules/fifo/iob_fifo_async/iob_fifo_async_tb.v
@@ -160,7 +160,7 @@ module iob_fifo_async_tb;
       end
 
       $display("INFO: TEST PASSED");
-      #100 $finish;
+      #100 $finish();
    end
 
    wire [        1-1:0] ext_mem_w_clk;

--- a/hardware/modules/fifo/iob_fifo_sync/iob_fifo_sync.v
+++ b/hardware/modules/fifo/iob_fifo_sync/iob_fifo_sync.v
@@ -51,10 +51,10 @@ module iob_fifo_sync #(
    localparam [ADDR_W:0] FIFO_SIZE = {1'b1, {ADDR_W{1'b0}}};  //in bytes
 
    //effective write enable
-   wire                w_en_int = (w_en_i & (~w_full_o));
+   wire w_en_int = (w_en_i & (~w_full_o));
 
    //write address
-   wire [W_ADDR_W-1:0] w_addr;
+   wire                                    [W_ADDR_W-1:0] w_addr;
    iob_counter #(
        .DATA_W (W_ADDR_W),
        .RST_VAL({W_ADDR_W{1'd0}})
@@ -69,10 +69,10 @@ module iob_fifo_sync #(
    );
 
    //effective read enable
-   wire                r_en_int = (r_en_i & (~r_empty_o));
+   wire r_en_int = (r_en_i & (~r_empty_o));
 
    //read address
-   wire [R_ADDR_W-1:0] r_addr;
+   wire                                     [R_ADDR_W-1:0] r_addr;
    iob_counter #(
        .DATA_W (R_ADDR_W),
        .RST_VAL({R_ADDR_W{1'd0}})

--- a/hardware/modules/fifo/iob_fifo_sync/iob_fifo_sync_tb.v
+++ b/hardware/modules/fifo/iob_fifo_sync/iob_fifo_sync_tb.v
@@ -165,7 +165,7 @@ module iob_fifo_sync_tb;
       end
       $display("INFO: read proc: data read matches test data as expected");
 
-      #(5 * clk_per) $finish;
+      #(5 * clk_per) $finish();
    end
 
    // Instantiate the Unit Under Test (UUT)

--- a/hardware/modules/iob2axi/iob2axi_rd.v
+++ b/hardware/modules/iob2axi/iob2axi_rd.v
@@ -44,19 +44,19 @@ module iob2axi_rd #(
 
    // Counter, error and ready register signals
    reg [`AXI_LEN_W-1:0] counter, counter_nxt;
-   reg                   error_nxt;
-   reg                   ready_nxt;
+   reg                                                    error_nxt;
+   reg                                                    ready_nxt;
 
-   reg                   m_axi_arvalid_int;
-   reg                   m_axi_rready_int;
+   reg                                                    m_axi_arvalid_int;
+   reg                                                    m_axi_rready_int;
 
    // Control register signals
-   reg  [    ADDR_W-1:0] addr_reg;
-   reg  [`AXI_LEN_W-1:0] length_reg;
+   reg                                   [    ADDR_W-1:0] addr_reg;
+   reg                                   [`AXI_LEN_W-1:0] length_reg;
 
    // Hold
-   reg                   m_valid_reg;
-   wire                  hold = m_valid_reg & ~m_ready_i;
+   reg                                                    m_valid_reg;
+   wire hold = m_valid_reg & ~m_ready_i;
    always @(posedge clk_i, posedge rst_i) begin
       if (rst_i) begin
          m_valid_reg <= 1'b0;
@@ -117,7 +117,7 @@ module iob2axi_rd #(
    end
 
    wire rst_valid_int = (state_nxt == ADDR_HS) ? 1'b1 : 1'b0;
-   reg  arvalid_int;
+   reg                                                        arvalid_int;
 
    always @(posedge clk_i, posedge rst_i) begin
       if (rst_i) begin

--- a/hardware/modules/iob2axi/iob2axi_tb.disable.v
+++ b/hardware/modules/iob2axi/iob2axi_tb.disable.v
@@ -132,7 +132,7 @@ module iob2axi_tb;
 
       repeat (10) @(posedge clk) #1;
 
-      $finish;
+      $finish();
    end
 
    iob2axi #(

--- a/hardware/modules/iob_asym_converter/iob_asym_converter_tb.v
+++ b/hardware/modules/iob_asym_converter/iob_asym_converter_tb.v
@@ -101,7 +101,7 @@ module iob_asym_converter_tb;
 
       //wait 5 cycles and finish
       repeat (5) @(posedge clk) #1;
-      $finish;
+      $finish();
    end
 
    // instantiate the Unit Under Test (UUT)

--- a/hardware/modules/iob_ctls/iob_ctls.v
+++ b/hardware/modules/iob_ctls/iob_ctls.v
@@ -45,7 +45,7 @@ module iob_ctls #(
       count = 0;
 
       for (pos = 0; pos < N; pos = pos + 1)
-      if ((data_int2[pos] == 1'd0) && (count == pos)) count = pos + 1;
+         if ((data_int2[pos] == 1'd0) && (count == pos)) count = pos + 1;
    end
 
    assign count_o = count;

--- a/hardware/modules/iob_split/iob_split.v
+++ b/hardware/modules/iob_split/iob_split.v
@@ -35,8 +35,8 @@ module iob_split #(
      $display("s_sel %x", s_sel);
    */
       for (i = 0; i < N_SLAVES; i = i + 1)
-      if (i == s_sel) s_req_o[`REQ(i)] = m_req_i;
-      else s_req_o[`REQ(i)] = {(`REQ_W) {1'b0}};
+         if (i == s_sel) s_req_o[`REQ(i)] = m_req_i;
+         else s_req_o[`REQ(i)] = {(`REQ_W) {1'b0}};
    end
 
    //

--- a/hardware/modules/ram/iob_ram_2p/iob_ram_2p_tb.v
+++ b/hardware/modules/ram/iob_ram_2p/iob_ram_2p_tb.v
@@ -60,7 +60,7 @@ module iob_ram_2p_tb;
          if (r_data != 0) begin
             $display("ERROR: with r_en = 0, at position %0d, r_data should be 0 but is %d", i,
                      r_data);
-            $fatal;
+            $fatal();
          end
       end
 
@@ -74,7 +74,7 @@ module iob_ram_2p_tb;
          if (r_data != i + seq_ini) begin
             $display("ERROR: on position %0d, r_data is %d where it should be %0d", i, r_data,
                      i + seq_ini);
-            $fatal;
+            $fatal();
          end
       end
 
@@ -84,7 +84,7 @@ module iob_ram_2p_tb;
       $display("%c[1;34m", 27);
       $display("Test completed successfully.");
       $display("%c[0m", 27);
-      $finish;
+      $finish();
    end
 
    // Instantiate the Unit Under Test (UUT)

--- a/hardware/modules/ram/iob_ram_2p_be/iob_ram_2p_be_tb.v
+++ b/hardware/modules/ram/iob_ram_2p_be/iob_ram_2p_be_tb.v
@@ -63,7 +63,7 @@ module iob_ram_2p_be_tb;
          if (r_data != 0) begin
             $display("ERROR: with r_en = 0, at position %0d, r_data should be 0 but is %d", i,
                      r_data);
-            $fatal;
+            $fatal();
          end
       end
 
@@ -77,7 +77,7 @@ module iob_ram_2p_be_tb;
          if (r_data != i + seq_ini) begin
             $display("ERROR: on position %0d, r_data is %d where it should be %0d", i, r_data,
                      i + seq_ini);
-            $fatal;
+            $fatal();
          end
       end
 
@@ -87,7 +87,7 @@ module iob_ram_2p_be_tb;
       $display("%c[1;34m", 27);
       $display("Test completed successfully.");
       $display("%c[0m", 27);
-      $finish;
+      $finish();
    end
 
    // Instantiate the Unit Under Test (UUT)

--- a/hardware/modules/ram/iob_ram_2p_tiled/iob_ram_2p_tiled_tb.v
+++ b/hardware/modules/ram/iob_ram_2p_tiled/iob_ram_2p_tiled_tb.v
@@ -78,7 +78,7 @@ module iob_ram_2p_tiled_tb;
          if (r_data != 0) begin
             $display("ERROR: with r_en = 0, at position %0d, r_data should be 0 but is %d", i,
                      r_data);
-            $fatal;
+            $fatal();
          end
       end
 
@@ -92,7 +92,7 @@ module iob_ram_2p_tiled_tb;
          if (r_data != i + seq_ini) begin
             $display("ERROR: on position %0d, r_data is %d where it should be %0d", i, r_data,
                      i + seq_ini);
-            $fatal;
+            $fatal();
          end
       end
 
@@ -102,6 +102,6 @@ module iob_ram_2p_tiled_tb;
       $display("%c[1;34m", 27);
       $display("Test completed successfully.");
       $display("%c[0m", 27);
-      $finish;
+      $finish();
    end
 endmodule

--- a/hardware/modules/ram/iob_ram_dp/iob_ram_dp_tb.v
+++ b/hardware/modules/ram/iob_ram_dp/iob_ram_dp_tb.v
@@ -73,7 +73,7 @@ module iob_ram_dp_tb;
          if (i + seq_ini != q_a) begin
             $display("ERROR: write error in port A position %d, where data=%h but q_a=%h", i,
                      i + seq_ini, q_a);
-            $fatal;
+            $fatal();
          end
       end
 
@@ -103,7 +103,7 @@ module iob_ram_dp_tb;
          if (i + seq_ini != q_b) begin
             $display("ERROR: write error in port B position %d, where data=%h but q_b=%h", i,
                      i + seq_ini, q_b);
-            $fatal;
+            $fatal();
          end
       end
 
@@ -115,7 +115,7 @@ module iob_ram_dp_tb;
       $display("%c[1;34m", 27);
       $display("Test completed successfully.");
       $display("%c[0m", 27);
-      #(5 * clk_per) $finish;
+      #(5 * clk_per) $finish();
 
    end
 

--- a/hardware/modules/ram/iob_ram_dp_be/iob_ram_dp_be_tb.v
+++ b/hardware/modules/ram/iob_ram_dp_be/iob_ram_dp_be_tb.v
@@ -71,7 +71,7 @@ module iob_ram_dp_be_tb;
          if (i + seq_ini != data_outA) begin
             $display("ERROR: write error in port A position %d, where data=%h but data_outA=%h", i,
                      i + seq_ini, data_outA);
-            $fatal;
+            $fatal();
          end
       end
 
@@ -102,7 +102,7 @@ module iob_ram_dp_be_tb;
          if (i + seq_ini != data_outB) begin
             $display("ERROR: write error in port B position %d, where data=%h but data_outB=%h", i,
                      i + seq_ini, data_outB);
-            $fatal;
+            $fatal();
          end
       end
 
@@ -119,7 +119,7 @@ module iob_ram_dp_be_tb;
                $display(
                    "ERROR: read error in port A position %d, where data and data_outA are '%h' but should not be the same",
                    i, data_outA);
-               $fatal;
+               $fatal();
             end
          end
       end
@@ -135,7 +135,7 @@ module iob_ram_dp_be_tb;
             $display(
                 "ERROR: read error in port B position %d, where data and data_outB are '%h' but should not be the same",
                 i, data_outB);
-            $fatal;
+            $fatal();
          end
       end
 
@@ -146,7 +146,7 @@ module iob_ram_dp_be_tb;
       $display("%c[1;34m", 27);
       $display("Test completed successfully.");
       $display("%c[0m", 27);
-      #(5 * clk_per) $finish;
+      #(5 * clk_per) $finish();
 
    end
 

--- a/hardware/modules/ram/iob_ram_dp_be_xil/iob_ram_dp_be_xil_tb.v
+++ b/hardware/modules/ram/iob_ram_dp_be_xil/iob_ram_dp_be_xil_tb.v
@@ -71,7 +71,7 @@ module iob_ram_dp_be_xil_tb;
          if (i + seq_ini != data_outA) begin
             $display("ERROR: write error in port A position %d, where data=%h but data_outA=%h", i,
                      i + seq_ini, data_outA);
-            $fatal;
+            $fatal();
          end
       end
 
@@ -102,7 +102,7 @@ module iob_ram_dp_be_xil_tb;
          if (i + seq_ini != data_outB) begin
             $display("ERROR: write error in port B position %d, where data=%h but data_outB=%h", i,
                      i + seq_ini, data_outB);
-            $fatal;
+            $fatal();
          end
       end
 
@@ -119,7 +119,7 @@ module iob_ram_dp_be_xil_tb;
                $display(
                    "ERROR: read error in port A position %d, where data and data_outA are '%h' but should not be the same",
                    i, data_outA);
-               $fatal;
+               $fatal();
             end
          end
       end
@@ -135,7 +135,7 @@ module iob_ram_dp_be_xil_tb;
             $display(
                 "ERROR: read error in port B position %d, where data and data_outB are '%h' but should not be the same",
                 i, data_outB);
-            $fatal;
+            $fatal();
          end
       end
 
@@ -146,7 +146,7 @@ module iob_ram_dp_be_xil_tb;
       $display("%c[1;34m", 27);
       $display("Test completed successfully.");
       $display("%c[0m", 27);
-      #(5 * clk_per) $finish;
+      #(5 * clk_per) $finish();
 
    end
 

--- a/hardware/modules/ram/iob_ram_sp/iob_ram_sp_tb.v
+++ b/hardware/modules/ram/iob_ram_sp/iob_ram_sp_tb.v
@@ -61,7 +61,7 @@ module iob_ram_sp_tb;
             $display(
                 "ERROR: read error in data_out. \n \t i=%0d; data = %h when it should have been %0h",
                 i, i + seq_ini, data_out);
-            $fatal;
+            $fatal();
          end
       end
 
@@ -72,7 +72,7 @@ module iob_ram_sp_tb;
       $display("%c[1;34m", 27);
       $display("Test completed successfully.");
       $display("%c[0m", 27);
-      #(5 * clk_per) $finish;
+      #(5 * clk_per) $finish();
 
    end
 

--- a/hardware/modules/ram/iob_ram_sp_be/iob_ram_sp_be_tb.v
+++ b/hardware/modules/ram/iob_ram_sp_be/iob_ram_sp_be_tb.v
@@ -60,7 +60,7 @@ module iob_ram_sp_be_tb;
          if (i + seq_ini != data_out) begin
             $display("ERROR: write error in position %d, where data=%h but data_out=%h", i,
                      i + seq_ini, data_out);
-            $fatal;
+            $fatal();
          end
       end
 
@@ -75,7 +75,7 @@ module iob_ram_sp_be_tb;
             $display(
                 "ERROR: read error in position %d, where data and data_out are '%h' but should not be the same",
                 i, data_out);
-            $fatal;
+            $fatal();
          end
       end
 
@@ -86,7 +86,7 @@ module iob_ram_sp_be_tb;
       $display("%c[1;34m", 27);
       $display("Test completed successfully.");
       $display("%c[0m", 27);
-      #(5 * clk_per) $finish;
+      #(5 * clk_per) $finish();
 
    end
 

--- a/hardware/modules/ram/iob_ram_t2p/iob_ram_t2p_tb.v
+++ b/hardware/modules/ram/iob_ram_t2p/iob_ram_t2p_tb.v
@@ -66,7 +66,7 @@ module iob_ram_t2p_tb;
          if (r_data != 0) begin
             $display("ERROR: with r_en = 0, at position %0d, r_data should be 0 but is %d", i,
                      r_data);
-            $finish;
+            $finish();
          end
       end
 
@@ -80,7 +80,7 @@ module iob_ram_t2p_tb;
          if (r_data != i + seq_ini) begin
             $display("ERROR: on position %0d, r_data is %d where it should be %0d", i, r_data,
                      i + seq_ini);
-            $finish;
+            $finish();
          end
       end
 
@@ -90,7 +90,7 @@ module iob_ram_t2p_tb;
       $display("%c[1;34m", 27);
       $display("Test completed successfully.");
       $display("%c[0m", 27);
-      $finish;
+      $finish();
    end
 
    // Instantiate the Unit Under Test (UUT)

--- a/hardware/modules/ram/iob_ram_tdp/iob_ram_tdp.v
+++ b/hardware/modules/ram/iob_ram_tdp/iob_ram_tdp.v
@@ -40,9 +40,9 @@ module iob_ram_tdp
       if (enA_i)
         if (weA_i)
 	        ram[addrA_i] <= dA_i;
-      `ifdef IOB_MEM_NO_READ_ON_WRITE
+`ifdef IOB_MEM_NO_READ_ON_WRITE
         else
-      `endif
+`endif
       dA_o <= ram[addrA_i];
     end
 

--- a/hardware/modules/ram/iob_ram_tdp/iob_ram_tdp_tb.v
+++ b/hardware/modules/ram/iob_ram_tdp/iob_ram_tdp_tb.v
@@ -77,7 +77,7 @@ module iob_ram_tdp_tb;
          if (i + seq_ini != q_a) begin
             $display("ERROR: write error in port A position %d, where data=%h but q_a=%h", i,
                      i + seq_ini, q_a);
-            $finish;
+            $finish();
          end
       end
 
@@ -107,7 +107,7 @@ module iob_ram_tdp_tb;
          if (i + seq_ini != q_b) begin
             $display("ERROR: write error in port B position %d, where data=%h but q_b=%h", i,
                      i + seq_ini, q_b);
-            $finish;
+            $finish();
          end
       end
 
@@ -119,7 +119,7 @@ module iob_ram_tdp_tb;
       $display("%c[1;34m", 27);
       $display("Test completed successfully.");
       $display("%c[0m", 27);
-      #(5 * clk_per) $finish;
+      #(5 * clk_per) $finish();
 
    end
 

--- a/hardware/modules/ram/iob_ram_tdp_be/iob_ram_tdp_be_tb.v
+++ b/hardware/modules/ram/iob_ram_tdp_be/iob_ram_tdp_be_tb.v
@@ -78,7 +78,7 @@ module iob_ram_tdp_be_tb;
          if (i + seq_ini != data_outA) begin
             $display("ERROR: write error in port A position %d, where data=%h but data_outA=%h", i,
                      i + seq_ini, data_outA);
-            $finish;
+            $finish();
          end
       end
 
@@ -109,7 +109,7 @@ module iob_ram_tdp_be_tb;
          if (i + seq_ini != data_outB) begin
             $display("ERROR: write error in port B position %d, where data=%h but data_outB=%h", i,
                      i + seq_ini, data_outB);
-            $finish;
+            $finish();
          end
       end
 
@@ -125,7 +125,7 @@ module iob_ram_tdp_be_tb;
             $display(
                 "ERROR: read error in port A position %d, where data and data_outA are '%h' but should not be the same",
                 i, data_outA);
-            $finish;
+            $finish();
          end
       end
 
@@ -140,7 +140,7 @@ module iob_ram_tdp_be_tb;
             $display(
                 "ERROR: read error in port B position %d, where data and data_outB are '%h' but should not be the same",
                 i, data_outB);
-            $finish;
+            $finish();
          end
       end
 
@@ -151,7 +151,7 @@ module iob_ram_tdp_be_tb;
       $display("%c[1;34m", 27);
       $display("Test completed successfully.");
       $display("%c[0m", 27);
-      #(5 * clk_per) $finish;
+      #(5 * clk_per) $finish();
 
    end
 

--- a/hardware/modules/regfile/iob_regfile_dp/iob_regfile_dp.v
+++ b/hardware/modules/regfile/iob_regfile_dp/iob_regfile_dp.v
@@ -22,11 +22,11 @@ module iob_regfile_dp #(
     output [DATA_W-1 : 0] b_rdata_o
 );
 
-   reg  [DATA_W-1:0] reg_file                                [(2**ADDR_W)-1:0];
+   reg [DATA_W-1:0] reg_file[(2**ADDR_W)-1:0];
 
    wire [ADDR_W-1:0] addr = a_wen_i ? a_addr_i : b_addr_i;
    wire [DATA_W-1:0] wdata = a_wen_i ? a_wdata_i : b_wdata_i;
-   wire              wen = a_wen_i ? a_wen_i : b_wen_i;
+   wire wen = a_wen_i ? a_wen_i : b_wen_i;
 
    //read
    assign a_rdata_o = reg_file[a_addr_i];

--- a/hardware/modules/regfile/iob_regfile_dp/iob_regfile_dp_tb.v
+++ b/hardware/modules/regfile/iob_regfile_dp/iob_regfile_dp_tb.v
@@ -61,7 +61,7 @@ module iob_regfile_dp_tb;
          @(posedge clk) #1;
          if (rdataA != i + seq_ini) begin
             $display("ERROR: read error in rdata.\n \t data=%0d; rdata=%0d", i + seq_ini, rdataA);
-            $finish;
+            $finish();
          end
          @(posedge clk) #1;
       end
@@ -76,7 +76,7 @@ module iob_regfile_dp_tb;
          @(posedge clk) #1;
          if (rdataA != i + seq_ini) begin
             $display("ERROR: read error in rdata.\n \t data=%0d; rdata=%0d", i + seq_ini, rdataA);
-            $finish;
+            $finish();
          end
          @(posedge clk) #1;
       end
@@ -93,7 +93,7 @@ module iob_regfile_dp_tb;
          @(posedge clk) #1;
          if (rdataA != 0) begin
             $display("ERROR: rdata is not null");
-            $finish;
+            $finish();
          end
          @(posedge clk) #1;
       end
@@ -111,7 +111,7 @@ module iob_regfile_dp_tb;
          @(posedge clk) #1;
          if (rdataB != i + seq_ini) begin
             $display("ERROR: read error in rdata.\n \t data=%0d; rdata=%0d", i + seq_ini, rdataB);
-            $finish;
+            $finish();
          end
          @(posedge clk) #1;
       end
@@ -126,7 +126,7 @@ module iob_regfile_dp_tb;
          @(posedge clk) #1;
          if (rdataB != i + seq_ini) begin
             $display("ERROR: read error in rdata.\n \t data=%0d; rdata=%0d", i + seq_ini, rdataB);
-            $finish;
+            $finish();
          end
          @(posedge clk) #1;
       end
@@ -143,7 +143,7 @@ module iob_regfile_dp_tb;
          @(posedge clk) #1;
          if (rdataB != 0) begin
             $display("ERROR: rdata is not null");
-            $finish;
+            $finish();
          end
          @(posedge clk) #1;
       end
@@ -152,7 +152,7 @@ module iob_regfile_dp_tb;
       $display("%c[1;34m", 27);
       $display("Test completed successfully.");
       $display("%c[0m", 27);
-      #(5 * clk_per) $finish;
+      #(5 * clk_per) $finish();
    end
 
    // Instantiate the Unit Under Test (UUT)

--- a/hardware/modules/regfile/iob_regfile_sp/iob_regfile_sp_tb.v
+++ b/hardware/modules/regfile/iob_regfile_sp/iob_regfile_sp_tb.v
@@ -52,7 +52,7 @@ module iob_regfile_sp_tb;
          @(posedge clk) #1;
          if (r_data != i + seq_ini) begin
             $display("ERROR: read error in r_data.\n \t data=%0d; r_data=%0d", i + seq_ini, r_data);
-            $finish;
+            $finish();
          end
          @(posedge clk) #1;
       end
@@ -67,7 +67,7 @@ module iob_regfile_sp_tb;
          @(posedge clk) #1;
          if (r_data != i + seq_ini) begin
             $display("ERROR: read error in r_data.\n \t data=%0d; r_data=%0d", i + seq_ini, r_data);
-            $finish;
+            $finish();
          end
          @(posedge clk) #1;
       end
@@ -84,7 +84,7 @@ module iob_regfile_sp_tb;
          @(posedge clk) #1;
          if (r_data != 0) begin
             $display("ERROR: r_data is not null");
-            $finish;
+            $finish();
          end
          @(posedge clk) #1;
       end
@@ -93,7 +93,7 @@ module iob_regfile_sp_tb;
       $display("%c[1;34m", 27);
       $display("Test completed successfully.");
       $display("%c[0m", 27);
-      #(5 * clk_per) $finish;
+      #(5 * clk_per) $finish();
    end
 
    // Instantiate the Unit Under Test (UUT)

--- a/hardware/modules/rom/iob_rom_dp/iob_rom_dp_tb.v
+++ b/hardware/modules/rom/iob_rom_dp/iob_rom_dp_tb.v
@@ -55,13 +55,13 @@ module iob_rom_dp_tb;
             $display(
                 "ERROR: Port A - read error in position %d, where expected data=%h but r_data=%h",
                 i, i + seq_ini, r_data_a);
-            $fatal;
+            $fatal();
          end
          if (seq_ini + 2 ** `ADDR_W - 1 - i != r_data_b) begin
             $display(
                 "ERROR: Port B - read error in position %d, where expected data=%h but r_data=%h",
                 2 ** `ADDR_W - 1 - i, seq_ini + 2 ** `ADDR_W - 1 - i, r_data_b);
-            $fatal;
+            $fatal();
          end
       end
 
@@ -73,7 +73,7 @@ module iob_rom_dp_tb;
       $display("%c[1;34m", 27);
       $display("Test completed successfully.");
       $display("%c[0m", 27);
-      #(5 * clk_per) $finish;
+      #(5 * clk_per) $finish();
 
    end
 

--- a/hardware/modules/rom/iob_rom_sp/iob_rom_sp_tb.v
+++ b/hardware/modules/rom/iob_rom_sp/iob_rom_sp_tb.v
@@ -46,7 +46,7 @@ module iob_rom_sp_tb;
          if (i + seq_ini != r_data) begin
             $display("ERROR: read error in position %d, where expected data=%h but r_data=%h", i,
                      i + seq_ini, r_data);
-            $fatal;
+            $fatal();
          end
       end
 
@@ -57,7 +57,7 @@ module iob_rom_sp_tb;
       $display("%c[1;34m", 27);
       $display("Test completed successfully.");
       $display("%c[0m", 27);
-      #(5 * clk_per) $finish;
+      #(5 * clk_per) $finish();
 
    end
 

--- a/hardware/modules/rom/iob_rom_tdp/iob_rom_tdp_tb.v
+++ b/hardware/modules/rom/iob_rom_tdp/iob_rom_tdp_tb.v
@@ -60,13 +60,13 @@ module iob_rom_tdp_tb;
             $display(
                 "ERROR: Port A - read error in position %d, where expected data=%h but r_data=%h",
                 i, i + seq_ini, r_data_a);
-            $fatal;
+            $fatal();
          end
          if (seq_ini + 2 ** `ADDR_W - 1 - i != r_data_b) begin
             $display(
                 "ERROR: Port B - read error in position %d, where expected data=%h but r_data=%h",
                 2 ** `ADDR_W - 1 - i, seq_ini + 2 ** `ADDR_W - 1 - i, r_data_b);
-            $fatal;
+            $fatal();
          end
       end
 
@@ -78,7 +78,7 @@ module iob_rom_tdp_tb;
       $display("%c[1;34m", 27);
       $display("Test completed successfully.");
       $display("%c[0m", 27);
-      #(5 * clk_per) $finish;
+      #(5 * clk_per) $finish();
 
    end
 


### PR DESCRIPTION
- fix `$finish()` and `$fatal()` macros in testbenches
- format some verilog files
- there are still verilog files with problems