### PR TITLE
format verilog files, add libreoffice to nix, lint verilog sources

### DIFF
--- a/hardware/modules/axis2axi/AxiDelay.v
+++ b/hardware/modules/axis2axi/AxiDelay.v
@@ -20,7 +20,7 @@ module AxiDelay #(
 
    generate
       if (MAX_DELAY == 0) begin
-         always @* begin
+         always_comb begin
             s_ready = m_ready;
             m_valid = s_valid;
          end
@@ -38,7 +38,7 @@ module AxiDelay #(
             end
          end
 
-         always @* begin
+         always_comb begin
             s_ready = 1'b0;
             m_valid = 1'b0;
 

--- a/hardware/modules/axis2axi/axis2axi_in.v
+++ b/hardware/modules/axis2axi/axis2axi_in.v
@@ -84,7 +84,7 @@ module axis2axi_in #(
    wire [BURST_W:0] burst_size;
 
    reg [BURST_W:0] non_boundary_burst_size;
-   always @* begin
+   always_comb begin
       non_boundary_burst_size = 0;
 
       if (last_burst_possible) begin
@@ -99,7 +99,7 @@ module axis2axi_in #(
          wire [12:0] boundary_transfer_len = (13'h1000 - current_address[11:0]) >> 2;
 
          reg [BURST_W:0] boundary_burst_size;
-         always @* begin
+         always_comb begin
             boundary_burst_size = non_boundary_burst_size;
 
             if (non_boundary_burst_size > boundary_transfer_len)
@@ -128,7 +128,7 @@ module axis2axi_in #(
    assign config_in_ready_o = (fifo_empty && state == WAIT_DATA);
 
    // State machine
-   always @* begin
+   always_comb begin
       state_nxt    = state;
       awvalid_int  = 1'b0;
       wvalid_int   = 1'b0;

--- a/hardware/modules/axis2axi/axis2axi_out.v
+++ b/hardware/modules/axis2axi/axis2axi_out.v
@@ -69,7 +69,7 @@ module axis2axi_out #(
    wire [BURST_W:0] burst_size;
 
    reg [BURST_W:0] non_boundary_burst_size;
-   always @* begin
+   always_comb begin
       non_boundary_burst_size = 0;
 
       if (last_burst_possible) begin
@@ -84,7 +84,7 @@ module axis2axi_out #(
          wire [12:0] boundary_transfer_len = (13'h1000 - current_address[11:0]) >> 2;
 
          reg [BURST_W:0] boundary_burst_size;
-         always @* begin
+         always_comb begin
             boundary_burst_size = non_boundary_burst_size;
 
             if (non_boundary_burst_size > boundary_transfer_len)
@@ -110,7 +110,7 @@ module axis2axi_out #(
    assign axi_arlen_o        = arlen_int;
    assign axi_arvalid_o      = arvalid_int;
 
-   always @* begin
+   always_comb begin
       state_nxt    = state;
       arvalid_int  = 1'b0;
       next_address = current_address;

--- a/hardware/modules/iob2axi/iob2axi.v
+++ b/hardware/modules/iob2axi/iob2axi.v
@@ -57,17 +57,17 @@ module iob2axi #(
    //
    // Input FIFO
    //
-   wire                       in_fifo_full;
-   wire                       in_fifo_wr = s_valid_i & |s_wstrb_i & ~in_fifo_full;
+   wire in_fifo_full;
+   wire in_fifo_wr = s_valid_i & |s_wstrb_i & ~in_fifo_full;
    wire [DATA_W+DATA_W/8-1:0] in_fifo_wdata = {s_wdata_i, s_wstrb_i};
 
-   wire                       in_fifo_empty;
-   wire                       in_fifo_rd = wr_valid;
+   wire in_fifo_empty;
+   wire in_fifo_rd = wr_valid;
    wire [DATA_W+DATA_W/8-1:0] in_fifo_rdata;
 
-   wire [       `AXI_LEN_W:0] in_fifo_level;
+   wire [`AXI_LEN_W:0] in_fifo_level;
 
-   reg                        in_fifo_empty_reg;
+   reg in_fifo_empty_reg;
    always @(posedge clk_i, posedge rst_i) begin
       if (rst_i) begin
          in_fifo_empty_reg <= 1'b1;
@@ -121,18 +121,18 @@ module iob2axi #(
    //
    // Output FIFO
    //
-   wire                out_fifo_full;
-   wire                out_fifo_wr = rd_valid & |rd_wstrb & ~out_fifo_full;
-   wire [  DATA_W-1:0] out_fifo_wdata = rd_wdata;
+   wire out_fifo_full;
+   wire out_fifo_wr = rd_valid & |rd_wstrb & ~out_fifo_full;
+   wire [DATA_W-1:0] out_fifo_wdata = rd_wdata;
 
-   wire                out_fifo_empty;
-   wire                out_fifo_rd = s_valid_i & ~|s_wstrb_i & ~out_fifo_empty;
-   wire [  DATA_W-1:0] out_fifo_rdata;
+   wire out_fifo_empty;
+   wire out_fifo_rd = s_valid_i & ~|s_wstrb_i & ~out_fifo_empty;
+   wire [DATA_W-1:0] out_fifo_rdata;
 
    wire [`AXI_LEN_W:0] out_fifo_level;
    wire [`AXI_LEN_W:0] out_fifo_capacity = {1'b1, `AXI_LEN_W'd0} - out_fifo_level;
 
-   reg                 out_fifo_empty_reg;
+   reg out_fifo_empty_reg;
    always @(posedge clk_i, posedge rst_i) begin
       if (rst_i) begin
          out_fifo_empty_reg <= 1'b1;
@@ -185,10 +185,10 @@ module iob2axi #(
    //
    // Compute next run
    //
-   wire [  `AXI_LEN_W:0] length_int = direction ? in_fifo_level : out_fifo_capacity;
+   wire [`AXI_LEN_W:0] length_int = direction ? in_fifo_level : out_fifo_capacity;
 
-   reg  [`AXI_LEN_W-1:0] count;
-   wire                  count_en = ~&count & |length_int;
+   reg [`AXI_LEN_W-1:0] count;
+   wire count_en = ~&count & |length_int;
 
    assign run_int   = ready_int & |length_int & (length_int[`AXI_LEN_W] | &count);
    assign run_wr    = direction ? run_int : 1'b0;
@@ -211,13 +211,13 @@ module iob2axi #(
    //
    localparam WADDR_W = ADDR_W - $clog2(DATA_W / 8);  // Word address width
 
-   reg  [`AXI_LEN_W-1:0] length_burst;
+   reg [`AXI_LEN_W-1:0] length_burst;
 
-   reg  [    ADDR_W-1:0] addr_int;
-   reg  [   WADDR_W-1:0] addr_int_next;
-   wire [   WADDR_W-1:0] addr4k = {addr_int[ADDR_W-1:12], {(12 - (ADDR_W - WADDR_W)) {1'b1}}};
-   wire [   WADDR_W-1:0] addrRem = addr_int[ADDR_W-1-:WADDR_W] + length_int - 1'b1;
-   wire [   WADDR_W-1:0] minAddr = `IOB_MIN(addr4k, addrRem);
+   reg [ADDR_W-1:0] addr_int;
+   reg [WADDR_W-1:0] addr_int_next;
+   wire [WADDR_W-1:0] addr4k = {addr_int[ADDR_W-1:12], {(12 - (ADDR_W - WADDR_W)) {1'b1}}};
+   wire [WADDR_W-1:0] addrRem = addr_int[ADDR_W-1-:WADDR_W] + length_int - 1'b1;
+   wire [WADDR_W-1:0] minAddr = `IOB_MIN(addr4k, addrRem);
 
    always @(posedge clk_i, posedge rst_i) begin
       if (rst_i) begin

--- a/hardware/modules/iob2axi/iob2axi.v
+++ b/hardware/modules/iob2axi/iob2axi.v
@@ -229,7 +229,7 @@ module iob2axi #(
       end
    end
 
-   always @* begin
+   always_comb begin
       addr_int_next = minAddr + 1'b1;
 
       if (minAddr == addr4k) begin

--- a/hardware/modules/iob2axi/iob2axi_rd.v
+++ b/hardware/modules/iob2axi/iob2axi_rd.v
@@ -143,7 +143,7 @@ module iob2axi_rd #(
    end
 
    // State machine
-   always @* begin
+   always_comb begin
       state_nxt         = state;
 
       error_nxt         = error_o;

--- a/hardware/modules/iob2axi/iob2axi_wr.v
+++ b/hardware/modules/iob2axi/iob2axi_wr.v
@@ -137,7 +137,7 @@ module iob2axi_wr #(
    end
 
    // State machine
-   always @* begin
+   always_comb begin
       state_nxt         = state;
 
       error_nxt         = error_o;

--- a/hardware/modules/iob_demux/iob_demux.v
+++ b/hardware/modules/iob_demux/iob_demux.v
@@ -11,7 +11,7 @@ module iob_demux #(
 );
 
    //integer i;
-   //always @* begin
+   //always_comb begin
    //    for (i=0; i<N; i=i+1)
    //        if(i == sel_i) begin
    //            data_o[i*DATA_W += DATA_W] = data_i;

--- a/hardware/modules/iob_lib.vh
+++ b/hardware/modules/iob_lib.vh
@@ -1,4 +1,4 @@
-`define IOB_COMB always @*
+`define IOB_COMB always_comb
 
 //IO
 `define IOB_INPUT(NAME, WIDTH) input [WIDTH-1:0] NAME

--- a/hardware/modules/iob_merge/iob_merge.v
+++ b/hardware/modules/iob_merge/iob_merge.v
@@ -39,7 +39,7 @@ module iob_merge #(
 
    //select master
    integer k;
-   always @* begin
+   always_comb begin
       sel = {Nb{1'b0}};
       for (k = 0; k < N_MASTERS; k = k + 1)
          if (~sel_en) sel = sel_reg;
@@ -50,7 +50,7 @@ module iob_merge #(
    //route master request to slave
    //  
    integer i;
-   always @* begin
+   always_comb begin
       s_req_o = {`REQ_W{1'b0}};
       for (i = 0; i < N_MASTERS; i = i + 1) if (i == sel) s_req_o = m_req_i[`REQ(i)];
    end
@@ -67,7 +67,7 @@ module iob_merge #(
 
    //route
    integer j;
-   always @* begin
+   always_comb begin
       for (j = 0; j < N_MASTERS; j = j + 1)
          if (j == sel_reg) m_resp_o[`RESP(j)] = s_resp_i;
          else m_resp_o[`RESP(j)] = {`RESP_W{1'b0}};

--- a/hardware/modules/iob_merge/iob_merge.v
+++ b/hardware/modules/iob_merge/iob_merge.v
@@ -2,66 +2,57 @@
 
 
 
-module iob_merge
-  #(
+module iob_merge #(
     parameter N_MASTERS = 2,
-    parameter DATA_W = 32,
-    parameter ADDR_W = 32
-    )
-   (
+    parameter DATA_W    = 32,
+    parameter ADDR_W    = 32
+) (
 
-    input                              clk_i,
-    input                              arst_i,
+    input clk_i,
+    input arst_i,
 
     //masters interface
-    input [N_MASTERS*`REQ_W-1:0]       m_req_i,
+    input      [ N_MASTERS*`REQ_W-1:0] m_req_i,
     output reg [N_MASTERS*`RESP_W-1:0] m_resp_o,
 
     //slave interface
-    output reg [`REQ_W-1:0]            s_req_o,
-    input [`RESP_W-1:0]                s_resp_i
-    );
+    output reg [ `REQ_W-1:0] s_req_o,
+    input      [`RESP_W-1:0] s_resp_i
+);
 
 
-   localparam Nb=$clog2(N_MASTERS)+($clog2(N_MASTERS)==0);
-   
+   localparam Nb = $clog2(N_MASTERS) + ($clog2(N_MASTERS) == 0);
+
 
    //                               
    //priority encoder: most significant bus has priority   
    //
-   reg [Nb-1:0]                        sel, sel_reg;
-   
-   //select enable
-   reg                                 sel_en; 
-   always @(posedge clk_i, posedge arst_i)
-     if(arst_i)
-       sel_en <= 1'b1;
-     else if(s_req_o[`AVALID(0)])
-       sel_en <= 1'b0;
-     else if(s_resp_i[`READY(0)])
-       sel_en <= ~s_req_o[`AVALID(0)];
+   reg [Nb-1:0] sel, sel_reg;
 
-   
+   //select enable
+   reg sel_en;
+   always @(posedge clk_i, posedge arst_i)
+      if (arst_i) sel_en <= 1'b1;
+      else if (s_req_o[`AVALID(0)]) sel_en <= 1'b0;
+      else if (s_resp_i[`READY(0)]) sel_en <= ~s_req_o[`AVALID(0)];
+
+
    //select master
-   integer                             k; 
+   integer k;
    always @* begin
       sel = {Nb{1'b0}};
-      for (k=0; k<N_MASTERS; k=k+1)
-        if (~sel_en)
-          sel = sel_reg;
-        else if( m_req_i[`AVALID(k)] )
-          sel = k[Nb-1:0];          
+      for (k = 0; k < N_MASTERS; k = k + 1)
+         if (~sel_en) sel = sel_reg;
+         else if (m_req_i[`AVALID(k)]) sel = k[Nb-1:0];
    end
-   
+
    //
    //route master request to slave
    //  
-   integer                             i;
+   integer i;
    always @* begin
       s_req_o = {`REQ_W{1'b0}};
-      for (i=0; i<N_MASTERS; i=i+1)
-        if( i == sel )
-          s_req_o = m_req_i[`REQ(i)];
+      for (i = 0; i < N_MASTERS; i = i + 1) if (i == sel) s_req_o = m_req_i[`REQ(i)];
    end
 
    //
@@ -69,22 +60,18 @@ module iob_merge
    //
 
    //register master selection
-   always @( posedge clk_i, posedge arst_i ) begin
-      if( arst_i )
-        sel_reg <= {Nb{1'b0}};
-      else
-        sel_reg <= sel;
-   end
-   
-   //route
-   integer                             j;
-   always @* begin
-      for (j=0; j<N_MASTERS; j=j+1)
-        if( j == sel_reg )
-          m_resp_o[`RESP(j)] = s_resp_i;
-        else
-          m_resp_o[`RESP(j)] = {`RESP_W{1'b0}};
+   always @(posedge clk_i, posedge arst_i) begin
+      if (arst_i) sel_reg <= {Nb{1'b0}};
+      else sel_reg <= sel;
    end
 
-   
+   //route
+   integer j;
+   always @* begin
+      for (j = 0; j < N_MASTERS; j = j + 1)
+         if (j == sel_reg) m_resp_o[`RESP(j)] = s_resp_i;
+         else m_resp_o[`RESP(j)] = {`RESP_W{1'b0}};
+   end
+
+
 endmodule

--- a/hardware/modules/iob_mux/iob_mux.v
+++ b/hardware/modules/iob_mux/iob_mux.v
@@ -11,7 +11,7 @@ module iob_mux #(
 );
 
    integer i;
-   always @* begin
+   always_comb begin
       data_o = {DATA_W{1'b0}};
       for (i = 0; i < N; i = i + 1) begin : gen_mux
          if (i == sel_i) data_o = data_i[i*DATA_W+:DATA_W];

--- a/hardware/modules/iob_prio_enc/iob_prio_enc.v
+++ b/hardware/modules/iob_prio_enc/iob_prio_enc.v
@@ -13,12 +13,12 @@ module iob_prio_enc #(
    integer pos;
    generate
       if (PRIO == "LOWEST") begin
-         always @* begin
+         always_comb begin
             encoded_o = {($clog2(WIDTH) + 1) {1'd0}};  //In case input is 0
             for (pos = WIDTH - 1; pos != -1; pos = pos - 1) if (unencoded_i[pos]) encoded_o = pos;
          end
       end else begin  //PRIO == "HIGHEST"
-         always @* begin
+         always_comb begin
             encoded_o = WIDTH;  //In case input is 0
             for (pos = 0; pos != WIDTH; pos = pos + 1) if (unencoded_i[pos]) encoded_o = pos;
          end

--- a/hardware/modules/iob_split/iob_split.v
+++ b/hardware/modules/iob_split/iob_split.v
@@ -28,7 +28,7 @@ module iob_split #(
 
    //route master request to selected slave
    integer i;
-   always @* begin
+   always_comb begin
       /*
      $display("pslave %d", P_SLAVES+1);
      $display("mreq %x", m_req_i);
@@ -52,7 +52,7 @@ module iob_split #(
 
    //route
    integer j;
-   always @* begin
+   always_comb begin
       m_resp_o = {`RESP_W{1'b0}};
       for (j = 0; j < N_SLAVES; j = j + 1) if (j == s_sel_reg) m_resp_o = s_resp_i[`RESP(j)];
    end

--- a/hardware/modules/ram/iob_ram_2p_tiled/iob_ram_2p_tiled.v
+++ b/hardware/modules/ram/iob_ram_2p_tiled/iob_ram_2p_tiled.v
@@ -71,7 +71,7 @@ module decN #(
     output reg [        N_OUTPUTS-1:0] dec_o
 );
 
-   always @* begin
+   always_comb begin
       dec_o        = 0;
       dec_o[dec_i] = 1'b1;
    end
@@ -92,7 +92,7 @@ module muxN #(
     output reg [INPUT_W-1:0] data_o  // output port
 );
 
-   always @* begin
+   always_comb begin
       data_o = data_i[sel_i];
    end
 endmodule

--- a/hardware/modules/ram/iob_ram_tdp/iob_ram_tdp.v
+++ b/hardware/modules/ram/iob_ram_tdp/iob_ram_tdp.v
@@ -1,59 +1,57 @@
 `timescale 1 ns / 1 ps
 
-module iob_ram_tdp
-  #(
+module iob_ram_tdp #(
     parameter HEXFILE = "none",
-    parameter DATA_W = 0,
-    parameter ADDR_W = 0
-    )
-   (
+    parameter DATA_W  = 0,
+    parameter ADDR_W  = 0
+) (
     // Port A
     input                     clkA_i,
-    input [(DATA_W-1):0]      dA_i,
-    input [(ADDR_W-1):0]      addrA_i,
+    input      [(DATA_W-1):0] dA_i,
+    input      [(ADDR_W-1):0] addrA_i,
     input                     enA_i,
     input                     weA_i,
     output reg [(DATA_W-1):0] dA_o,
 
     // Port B
     input                     clkB_i,
-    input [(DATA_W-1):0]      dB_i,
-    input [(ADDR_W-1):0]      addrB_i,
+    input      [(DATA_W-1):0] dB_i,
+    input      [(ADDR_W-1):0] addrB_i,
     input                     enB_i,
     input                     weB_i,
     output reg [(DATA_W-1):0] dB_o
-    );
+);
 
    //this allows ISE 14.7 to work; do not remove
    localparam mem_init_file_int = HEXFILE;
 
    // Declare the RAM
-   reg [DATA_W-1:0]           ram[2**ADDR_W-1:0];
+   reg [DATA_W-1:0] ram[2**ADDR_W-1:0];
 
    // Initialize the RAM
-   initial
-     if(mem_init_file_int != "none")
-       $readmemh(mem_init_file_int, ram, 0, 2**ADDR_W - 1);
+   initial if (mem_init_file_int != "none") $readmemh(mem_init_file_int, ram, 0, 2 ** ADDR_W - 1);
 
    //read port
-   always @ (posedge clkA_i) begin// Port A
+   always @(posedge clkA_i) begin  // Port A
       if (enA_i)
-        if (weA_i)
-	        ram[addrA_i] <= dA_i;
 `ifdef IOB_MEM_NO_READ_ON_WRITE
-        else
+         if (weA_i) ram[addrA_i] <= dA_i;
+         else dA_o <= ram[addrA_i];
+`else
+         if (weA_i) ram[addrA_i] <= dA_i;
+         dA_o <= ram[addrA_i];
 `endif
-      dA_o <= ram[addrA_i];
-    end
+   end
 
    //write port
-   always @ (posedge clkB_i) begin // Port B
+   always @(posedge clkB_i) begin  // Port B
       if (enB_i)
-        if (weB_i)
-	        ram[addrB_i] <= dB_i;
-      `ifdef IOB_MEM_NO_READ_ON_WRITE
-        else
-      `endif
-	    dB_o <= ram[addrB_i];
-    end
- endmodule
+`ifdef IOB_MEM_NO_READ_ON_WRITE
+         if (weB_i) ram[addrB_i] <= dB_i;
+         else dB_o <= ram[addrB_i];
+`else
+         if (weB_i) ram[addrB_i] <= dB_i;
+         dB_o <= ram[addrB_i];
+`endif
+   end
+endmodule

--- a/scripts/shell.nix
+++ b/scripts/shell.nix
@@ -18,5 +18,6 @@ pkgs.mkShell {
     black
     llvmPackages_14.clangUseLLVM
     inkscape
+    libreoffice
   ];
 }


### PR DESCRIPTION
- notice that iob2axi.v and iob_merge.v can't pass verilog format due to
  processing macros with arguments (probably related with this issue:
  https://github.com/chipsalliance/verible/issues/1524)
- add libreoffice to nix shell environment, needed by document flow
- some verilog source linting