### PR TITLE
 fix(test): revert axi2axil always_combs 

### DIFF
--- a/hardware/modules/axis2axi/axis2axi_in.v
+++ b/hardware/modules/axis2axi/axis2axi_in.v
@@ -84,7 +84,7 @@ module axis2axi_in #(
    wire [BURST_W:0] burst_size;
 
    reg [BURST_W:0] non_boundary_burst_size;
-   always_comb begin
+   always @* begin
       non_boundary_burst_size = 0;
 
       if (last_burst_possible) begin
@@ -99,7 +99,7 @@ module axis2axi_in #(
          wire [12:0] boundary_transfer_len = (13'h1000 - current_address[11:0]) >> 2;
 
          reg [BURST_W:0] boundary_burst_size;
-         always_comb begin
+         always @* begin
             boundary_burst_size = non_boundary_burst_size;
 
             if (non_boundary_burst_size > boundary_transfer_len)
@@ -128,7 +128,7 @@ module axis2axi_in #(
    assign config_in_ready_o = (fifo_empty && state == WAIT_DATA);
 
    // State machine
-   always_comb begin
+   always @* begin
       state_nxt    = state;
       awvalid_int  = 1'b0;
       wvalid_int   = 1'b0;

--- a/hardware/modules/axis2axi/axis2axi_out.v
+++ b/hardware/modules/axis2axi/axis2axi_out.v
@@ -69,7 +69,7 @@ module axis2axi_out #(
    wire [BURST_W:0] burst_size;
 
    reg [BURST_W:0] non_boundary_burst_size;
-   always_comb begin
+   always @* begin
       non_boundary_burst_size = 0;
 
       if (last_burst_possible) begin
@@ -84,7 +84,7 @@ module axis2axi_out #(
          wire [12:0] boundary_transfer_len = (13'h1000 - current_address[11:0]) >> 2;
 
          reg [BURST_W:0] boundary_burst_size;
-         always_comb begin
+         always @* begin
             boundary_burst_size = non_boundary_burst_size;
 
             if (non_boundary_burst_size > boundary_transfer_len)

--- a/hardware/modules/iob2axi/iob2axi.v
+++ b/hardware/modules/iob2axi/iob2axi.v
@@ -1,5 +1,7 @@
 `timescale 1ns / 1ps
 
+`include "iob_utils.vh"
+
 
 
 module iob2axi #(

--- a/hardware/modules/iob_merge/iob_merge.v
+++ b/hardware/modules/iob_merge/iob_merge.v
@@ -1,5 +1,6 @@
 `timescale 1ns / 1ps
 
+`include "iob_utils.vh"
 
 
 module iob_merge #(


### PR DESCRIPTION
- revert axi2axil always_comb blocks to pass LIB tests
- need to review always @* processes more closely to convert to
  always_comb
- add missint includes to iob_merge and iob2axi