### PR TITLE
setup.mk, verilog-format.sh: find all .v, .vt and .vh; fix not to through an error when no files are passed

### DIFF
--- a/hardware/modules/iob_clkbuf/iob_clkbuf.v
+++ b/hardware/modules/iob_clkbuf/iob_clkbuf.v
@@ -1,6 +1,9 @@
 `timescale 1ns / 1ps
 
-module iob_clkbuf (
+module iob_clkbuf #(
+                    parameter DELAY = 0
+                    )
+(
     input  clk_i,
     input  n_i,
     output clk_o
@@ -14,7 +17,9 @@ module iob_clkbuf (
       .O(clk_o)
    );
 `else
-   assign clk_o = clk_int;
+   reg clk_v;
+   always @* clk_v = #DELAY clk_int;
+   assign clk_o = clk_v;
 `endif
 
 endmodule

--- a/hardware/modules/iob_clkmux/iob_clkmux.v
+++ b/hardware/modules/iob_clkmux/iob_clkmux.v
@@ -24,7 +24,9 @@ module iob_clkmux (
       .O (clk_o)
    );
 `else
-   assign clk_o = clk_sel_i ? clk1_i : clk0_i;
+   reg     clk_v;
+   always @* clk_v = #1 clk_sel_i ? clk1_i : clk0_i;
+   assign clk_o = clk_v;
 `endif
 
 endmodule

--- a/hardware/modules/iob_iobuf/iob_iobuf.v
+++ b/hardware/modules/iob_iobuf/iob_iobuf.v
@@ -25,10 +25,12 @@ module iob_iobuf (
       .IO(io)
    );
 `else
-   assign io    = t_i ? 1'bz : i;
-   assign o_int = io;
+   reg  o_var;
+   assign io = t_i ? 1'bz : i;
+   always @* o_var = #1 io;
+   assign o_int = o_var;
 `endif
 
-   assign o = n_i ^ o_int;
+   assign o = (n_i ^ o_int);
 
 endmodule

--- a/scripts/verilog-format.sh
+++ b/scripts/verilog-format.sh
@@ -1,3 +1,8 @@
 #!/usr/bin/env bash
 # run the command below for all files given as command line arguments
-verible-verilog-format --inplace `cat $IOB_LIB_PATH/verible-format.rules | tr '\n' ' '` $@
+if [ "$#" -eq 0 ]; then
+    echo "No files specified."
+    exit 0
+fi
+
+verible-verilog-format --inplace $(cat "$IOB_LIB_PATH/verible-format.rules" | tr '\n' ' ') "$@"

--- a/setup.mk
+++ b/setup.mk
@@ -55,15 +55,15 @@ export IOB_LIB_PATH
 
 verilog-lint:
 	# Run linter on all verilog files of setup directory
-	$(IOB_LIB_PATH)/verilog-lint.sh `find hardware -type f -name "*.v"  -name "*.vh" | tr '\n' ' '`
+	$(IOB_LIB_PATH)/verilog-lint.sh `find hardware -type f -name "*.v?" -o -name "*.v" | tr '\n' ' '`
 	# Run linter on all verilog files of build directory (includes generated files)
-	$(IOB_LIB_PATH)/verilog-lint.sh `find $(BUILD_DIR) -type f -name "*.v" -name "*.vh" | tr '\n' ' '`
+	$(IOB_LIB_PATH)/verilog-lint.sh `find $(BUILD_DIR) -type f -name "*.v?" -o -name "*.v" | tr '\n' ' '`
 
 verilog-format:
 	# Run formatter on all verilog files of setup directory
-	$(IOB_LIB_PATH)/verilog-format.sh `find  hardware -type f -name "*.v"| tr '\n' ' '`
+	$(IOB_LIB_PATH)/verilog-format.sh `find  hardware -type f -name "*.v?" -o -name "*.v" | tr '\n' ' '`
 	# Run formatter on all verilog files of build directory (includes generated files)
-	$(IOB_LIB_PATH)/verilog-format.sh `find $(BUILD_DIR) -type f -name "*.v"  | tr '\n' ' '`
+	$(IOB_LIB_PATH)/verilog-format.sh `find $(BUILD_DIR) -type f -name "*.v?" -o -name "*.v" | tr '\n' ' '`
 
 format-check-all: $(BUILD_DIR) python-format-check c-format-check verilog-lint verilog-format
 


### PR DESCRIPTION
@jjts Please check changes before accepting. 
There are changes that were imported from a pull, however they are not currently in the upstream repositor.