### PR TITLE
Object oriented

### DIFF
--- a/hardware/modules/iob2apb/iob2apb.py
+++ b/hardware/modules/iob2apb/iob2apb.py
@@ -4,10 +4,6 @@ import shutil
 from iob_module import iob_module
 from setup import setup
 
-from iob_s_port import iob_s_port
-from iob_s_s_portmap import iob_s_s_portmap
-from apb_m_port import apb_m_port
-from iob_m_tb_wire import iob_m_tb_wire
 from iob_reg import iob_reg
 
 
@@ -23,10 +19,10 @@ class iob2apb(iob_module):
 
         # Setup dependencies
 
-        iob_s_port.setup()
-        iob_s_s_portmap.setup()
-        apb_m_port.setup()
-        iob_m_tb_wire.setup()
+        iob_module.generate("iob_s_port")
+        iob_module.generate("iob_s_s_portmap")
+        iob_module.generate("apb_m_port")
+        iob_module.generate("iob_m_tb_wire")
 
         iob_reg.setup()
 

--- a/hardware/modules/iob_clkbuf/iob_clkbuf.py
+++ b/hardware/modules/iob_clkbuf/iob_clkbuf.py
@@ -38,5 +38,7 @@ class iob_clkbuf(iob_module):
             for purpose in [x for x in cls._setup_purpose[:-1] if x != "software"]:
                 # Delete sources for this purpose
                 os.remove(
-                    os.path.join(cls.build_dir, cls.PURPOSE_DIRS[purpose], "iob_clkbuf.v")
+                    os.path.join(
+                        cls.build_dir, cls.PURPOSE_DIRS[purpose], "iob_clkbuf.v"
+                    )
                 )

--- a/hardware/modules/iob_clkbuf/iob_clkbuf.py
+++ b/hardware/modules/iob_clkbuf/iob_clkbuf.py
@@ -4,11 +4,9 @@ import shutil
 from iob_module import iob_module
 from setup import setup
 
-from iob_reg import iob_reg
 
-
-class apb2iob(iob_module):
-    name = "apb2iob"
+class iob_clkbuf(iob_module):
+    name = "iob_clkbuf"
     version = "V0.10"
     flows = "sim"
     setup_dir = os.path.dirname(__file__)
@@ -18,10 +16,6 @@ class apb2iob(iob_module):
         super()._run_setup()
 
         # Setup dependencies
-        iob_module.generate("iob_wire")
-        iob_module.generate("apb_s_port")
-        iob_module.generate("iob_s_portmap")
-        iob_reg.setup()
 
         if cls.is_top_module:
             # Setup flows of this core using LIB setup function
@@ -33,8 +27,8 @@ class apb2iob(iob_module):
         out_dir = cls.get_purpose_dir(cls._setup_purpose[-1])
         # Copy source to build directory
         shutil.copyfile(
-            os.path.join(cls.setup_dir, "apb2iob.v"),
-            os.path.join(cls.build_dir, out_dir, "apb2iob.v"),
+            os.path.join(cls.setup_dir, "iob_clkbuf.v"),
+            os.path.join(cls.build_dir, out_dir, "iob_clkbuf.v"),
         )
 
         # Ensure sources of other purposes are deleted (except software)
@@ -44,5 +38,5 @@ class apb2iob(iob_module):
             for purpose in [x for x in cls._setup_purpose[:-1] if x != "software"]:
                 # Delete sources for this purpose
                 os.remove(
-                    os.path.join(cls.build_dir, cls.PURPOSE_DIRS[purpose], "apb2iob.v")
+                    os.path.join(cls.build_dir, cls.PURPOSE_DIRS[purpose], "iob_clkbuf.v")
                 )

--- a/hardware/modules/iob_clkmux/iob_clkmux.py
+++ b/hardware/modules/iob_clkmux/iob_clkmux.py
@@ -4,11 +4,9 @@ import shutil
 from iob_module import iob_module
 from setup import setup
 
-from iob_reg import iob_reg
 
-
-class apb2iob(iob_module):
-    name = "apb2iob"
+class iob_clkmux(iob_module):
+    name = "iob_clkmux"
     version = "V0.10"
     flows = "sim"
     setup_dir = os.path.dirname(__file__)
@@ -18,10 +16,6 @@ class apb2iob(iob_module):
         super()._run_setup()
 
         # Setup dependencies
-        iob_module.generate("iob_wire")
-        iob_module.generate("apb_s_port")
-        iob_module.generate("iob_s_portmap")
-        iob_reg.setup()
 
         if cls.is_top_module:
             # Setup flows of this core using LIB setup function
@@ -33,8 +27,8 @@ class apb2iob(iob_module):
         out_dir = cls.get_purpose_dir(cls._setup_purpose[-1])
         # Copy source to build directory
         shutil.copyfile(
-            os.path.join(cls.setup_dir, "apb2iob.v"),
-            os.path.join(cls.build_dir, out_dir, "apb2iob.v"),
+            os.path.join(cls.setup_dir, "iob_clkmux.v"),
+            os.path.join(cls.build_dir, out_dir, "iob_clkmux.v"),
         )
 
         # Ensure sources of other purposes are deleted (except software)
@@ -44,5 +38,5 @@ class apb2iob(iob_module):
             for purpose in [x for x in cls._setup_purpose[:-1] if x != "software"]:
                 # Delete sources for this purpose
                 os.remove(
-                    os.path.join(cls.build_dir, cls.PURPOSE_DIRS[purpose], "apb2iob.v")
+                    os.path.join(cls.build_dir, cls.PURPOSE_DIRS[purpose], "iob_clkmux.v")
                 )

--- a/hardware/modules/iob_clkmux/iob_clkmux.py
+++ b/hardware/modules/iob_clkmux/iob_clkmux.py
@@ -38,5 +38,7 @@ class iob_clkmux(iob_module):
             for purpose in [x for x in cls._setup_purpose[:-1] if x != "software"]:
                 # Delete sources for this purpose
                 os.remove(
-                    os.path.join(cls.build_dir, cls.PURPOSE_DIRS[purpose], "iob_clkmux.v")
+                    os.path.join(
+                        cls.build_dir, cls.PURPOSE_DIRS[purpose], "iob_clkmux.v"
+                    )
                 )

--- a/scripts/bootstrap.py
+++ b/scripts/bootstrap.py
@@ -75,6 +75,23 @@ for arg in sys.argv:
         build_srcs.LIB_DIR = arg.split("=")[1]
         break
 
+# Given a version string, return a 4 digit representation of that version.
+def version_from_str(version_str):
+    major, minor = version_str.replace("V", "").split(".")
+    version_str = f"{int(major):02d}{int(minor):02d}"
+    return version_str
+
+# Print Makefile variable definitions, used for delivery
+def get_delivery_vars():
+    top_module = vars(sys.modules[top_module_name])[top_module_name]
+    top_module.is_top_module = True
+    top_module.set_dynamic_attributes()
+    print(f'NAME={top_module.name} ', end="")
+    print(f'VERSION={version_from_str(top_module.version)} ', end="")
+    print(f'PREVIOUS_VERSION={version_from_str(top_module.previous_version)} ', end="")
+    print(f'VERSION_STR={top_module.version} ')
+
+
 # Print build directory attribute of the top module
 def get_build_dir():
     top_module = vars(sys.modules[top_module_name])[top_module_name]

--- a/scripts/bootstrap.py
+++ b/scripts/bootstrap.py
@@ -81,15 +81,16 @@ def version_from_str(version_str):
     version_str = f"{int(major):02d}{int(minor):02d}"
     return version_str
 
+
 # Print Makefile variable definitions, used for delivery
 def get_delivery_vars():
     top_module = vars(sys.modules[top_module_name])[top_module_name]
     top_module.is_top_module = True
     top_module.set_dynamic_attributes()
-    print(f'NAME={top_module.name} ', end="")
-    print(f'VERSION={version_from_str(top_module.version)} ', end="")
-    print(f'PREVIOUS_VERSION={version_from_str(top_module.previous_version)} ', end="")
-    print(f'VERSION_STR={top_module.version} ')
+    print(f"NAME={top_module.name} ", end="")
+    print(f"VERSION={version_from_str(top_module.version)} ", end="")
+    print(f"PREVIOUS_VERSION={version_from_str(top_module.previous_version)} ", end="")
+    print(f"VERSION_STR={top_module.version} ")
 
 
 # Print build directory attribute of the top module

--- a/scripts/build_srcs.py
+++ b/scripts/build_srcs.py
@@ -118,7 +118,7 @@ def lint_setup(python_module):
     setup_dir = python_module.setup_dir
     lint_dir = "hardware/lint"
 
-    os.mkdir(f"{build_dir}/{lint_dir}")
+    os.makedirs(f"{build_dir}/{lint_dir}", exist_ok=True)
     files = Path(f"{LIB_DIR}/{lint_dir}").glob("*")
     for file in files:
         file = os.path.basename(file)

--- a/scripts/iob_module.py
+++ b/scripts/iob_module.py
@@ -302,6 +302,7 @@ class iob_module:
                 ),
             )
             # print(f"### DEBUG: {src} {dst}")
+            file_perms = os.stat(src).st_mode
             with open(src, "r") as file:
                 lines = file.readlines()
             for idx in range(len(lines)):
@@ -312,5 +313,7 @@ class iob_module:
                 )
             with open(dst, "w") as file:
                 file.writelines(lines)
+            # Set file permissions equal to source file
+            os.chmod(dst, file_perms)
 
         return copy_func

--- a/scripts/iob_module.py
+++ b/scripts/iob_module.py
@@ -269,6 +269,8 @@ class iob_module:
                 "hardware/src",
                 "hardware/simulation",
                 "hardware/fpga",
+                "hardware/syn",
+                "hardware/lint",
                 "software",
             ]:
                 # Skip this directory if it does not exist

--- a/scripts/iob_module.py
+++ b/scripts/iob_module.py
@@ -12,6 +12,7 @@ class iob_module:
     # Standard attributes common to all iob-modules
     name = "iob_module"  # Verilog module name (not instance name)
     version = "1.0"  # Module version
+    previous_version = None  # Module version
     flows = ""  # Flows supported by this module
     setup_dir = ""  # Setup directory for this module
     build_dir = ""  # Build directory for this module
@@ -101,6 +102,10 @@ class iob_module:
 
         # Copy build directory from the `iob_module` superclass
         cls.build_dir = iob_module.build_dir
+
+        # Copy current version to previous version if it is not set
+        if not cls.previous_version:
+            cls.previous_version = cls.version
 
         # Initialize empty lists for attributes (We can't initialize in the attribute declaration because it would cause every subclass to reference the same list)
         cls.confs = []

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -36,17 +36,21 @@ def setup(python_module, no_overlap=False, disable_file_gen=False):
     #
     build_srcs.flows_setup(python_module)
 
-    # Auto-add 'VERSION' macro
-    confs.append(
-        {
-            "name": "VERSION",
-            "type": "M",
-            "val": "16'h" + build_srcs.version_str_to_digits(python_module.version),
-            "min": "NA",
-            "max": "NA",
-            "descr": "Product version. This 16-bit macro uses nibbles to represent decimal numbers using their binary values. The two most significant nibbles represent the integral part of the version, and the two least significant nibbles represent the decimal part. For example V12.34 is represented by 0x1234.",
-        }
-    )
+    # Auto-add 'VERSION' macro if it doesn't exist
+    for macro in confs:
+        if macro["name"] == "VERSION":
+            break
+    else:
+        confs.append(
+            {
+                "name": "VERSION",
+                "type": "M",
+                "val": "16'h" + build_srcs.version_str_to_digits(python_module.version),
+                "min": "NA",
+                "max": "NA",
+                "descr": "Product version. This 16-bit macro uses nibbles to represent decimal numbers using their binary values. The two most significant nibbles represent the integral part of the version, and the two least significant nibbles represent the decimal part. For example V12.34 is represented by 0x1234.",
+            }
+        )
 
     #
     # Build registers table
@@ -61,19 +65,24 @@ def setup(python_module, no_overlap=False, disable_file_gen=False):
                 "regs": [],
             }
             regs.append(general_regs_table)
-        # Auto add 'VERSION' register in 'general' registers table
-        general_regs_table["regs"].append(
-            {
-                "name": "VERSION",
-                "type": "R",
-                "n_bits": 16,
-                "rst_val": build_srcs.version_str_to_digits(python_module.version),
-                "addr": -1,
-                "log2n_items": 0,
-                "autologic": True,
-                "descr": "Product version.  This 16-bit register uses nibbles to represent decimal numbers using their binary values. The two most significant nibbles represent the integral part of the version, and the two least significant nibbles represent the decimal part. For example V12.34 is represented by 0x1234.",
-            }
-        )
+
+        # Auto add 'VERSION' register in 'general' registers table if it doesn't exist
+        for reg in general_regs_table["regs"]:
+            if reg["name"] == "VERSION":
+                break
+        else:
+            general_regs_table["regs"].append(
+                {
+                    "name": "VERSION",
+                    "type": "R",
+                    "n_bits": 16,
+                    "rst_val": build_srcs.version_str_to_digits(python_module.version),
+                    "addr": -1,
+                    "log2n_items": 0,
+                    "autologic": True,
+                    "descr": "Product version.  This 16-bit register uses nibbles to represent decimal numbers using their binary values. The two most significant nibbles represent the integral part of the version, and the two least significant nibbles represent the decimal part. For example V12.34 is represented by 0x1234.",
+                }
+            )
 
         # Create an instance of the mkregs class inside the mkregs module
         # This instance is only used locally, not affecting status of mkregs imported in other functions/modules


### PR DESCRIPTION
- Add missing python modules. 
- Set correct permissions in files copied during setup. 
- Only auto-append VERSION macros/regs if they don't exist already.
- Copy files from `syn` and `lint` directories  when running `_copy_srcs() `