### PR TITLE
Update extmem reserved signals; Fix order of file copy during setup; Only copy `hardware/src` and `software` from submodules.

### DIFF
--- a/hardware/fpga/Makefile
+++ b/hardware/fpga/Makefile
@@ -27,6 +27,8 @@ ifeq ($(FPGA_TOOL),)
 $(error Cannot find FPGA toolchain for board $(BOARD). Please make sure that the board name is correct and that the board is supported by the FPGA toolchain)
 endif
 
+N_INTERCONNECT_SLAVES ?=1
+
 include $(FPGA_TOOL)/$(BOARD)/board.mk
 include $(FPGA_TOOL)/build.mk
 

--- a/hardware/fpga/vivado/build.mk
+++ b/hardware/fpga/vivado/build.mk
@@ -23,7 +23,7 @@ FPGA_PROG=vivado -nojournal -log vivado.log -mode batch -source vivado/prog.tcl 
 # work-around for http://svn.clifford.at/handicraft/2016/vivadosig11
 export RDI_VERBOSE = False
 
-VIVADO_FLAGS= -nojournal -log reports/vivado.log -mode batch -source vivado/build.tcl -tclargs $(FPGA_TOP) $(BOARD) "$(VSRC)" "$(IP)" $(IS_FPGA) $(USE_EXTMEM)
+VIVADO_FLAGS= -nojournal -log reports/vivado.log -mode batch -source vivado/build.tcl -tclargs $(FPGA_TOP) $(BOARD) "$(VSRC)" "$(IP)" $(IS_FPGA) $(USE_EXTMEM) $(N_INTERCONNECT_SLAVES)
 
 $(FPGA_OBJ): $(VSRC) $(VHDR) $(IP) $(wildcard $(BOARD)/*.sdc)
 	mkdir -p reports && vivado $(VIVADO_FLAGS) 

--- a/hardware/fpga/vivado/build.tcl
+++ b/hardware/fpga/vivado/build.tcl
@@ -4,7 +4,8 @@ set BOARD [lindex $argv 1]
 set VSRC [lindex $argv 2]
 set VIP [lindex $argv 3]
 set IS_FPGA [lindex $argv 4]
-set CUSTOM_ARGS [lindex $argv 5]
+set USE_EXTMEM [lindex $argv 5]
+set N_INTERCONNECT_SLAVES [lindex $argv 6]
 
 #verilog sources
 foreach file [split $VSRC \ ] {

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -21,7 +21,7 @@ def getf(obj, name, field):
 
 # no_overlap: Optional argument. Selects if read/write register addresses should not overlap
 # disable_file_gen: Optional argument. Selects if files should be auto-generated.
-def setup(python_module, no_overlap=False, disable_file_gen=False):
+def setup(python_module, no_overlap=False, disable_file_gen=False, replace_includes=True):
     confs = python_module.confs
     ios = python_module.ios
     regs = python_module.regs
@@ -147,7 +147,7 @@ def setup(python_module, no_overlap=False, disable_file_gen=False):
             )
 
     # Replace Verilog includes by Verilog header file contents
-    if python_module.is_top_module:
+    if python_module.is_top_module and replace_includes:
         verilog_tools.replace_includes(python_module.setup_dir, build_dir)
 
 

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -29,11 +29,6 @@ def setup(python_module, no_overlap=False, disable_file_gen=False, replace_inclu
     top = python_module.name
     build_dir = python_module.build_dir
 
-    #
-    # Setup flows
-    #
-    build_srcs.flows_setup(python_module)
-
     # Auto-add 'VERSION' macro if it doesn't exist
     for macro in confs:
         if macro["name"] == "VERSION":
@@ -118,17 +113,18 @@ def setup(python_module, no_overlap=False, disable_file_gen=False, replace_inclu
         # Generate sw
         #
         if "emb" in python_module.flows:
+            os.makedirs(build_dir + "/software/src", exist_ok=True)
             if regs:
                 mkregs_obj.write_swheader(
-                    reg_table, python_module.build_dir + "/software/src", top
+                    reg_table, build_dir + "/software/src", top
                 )
                 mkregs_obj.write_swcode(
-                    reg_table, python_module.build_dir + "/software/src", top
+                    reg_table, build_dir + "/software/src", top
                 )
                 mkregs_obj.write_swheader(
-                    reg_table, python_module.build_dir + "/software/src", top
+                    reg_table, build_dir + "/software/src", top
                 )
-            mk_conf.conf_h(confs, top, python_module.build_dir + "/software/src")
+            mk_conf.conf_h(confs, top, build_dir + "/software/src")
 
         #
         # Generate TeX

--- a/scripts/submodule_utils.py
+++ b/scripts/submodule_utils.py
@@ -26,7 +26,7 @@ reserved_signals = {
     "iob_rdata_o": ".iob_rdata_o(slaves_resp[`RDATA(`/*<InstanceName>*/)])",
     "iob_ready_o": ".iob_ready_o(slaves_resp[`READY(`/*<InstanceName>*/)])",
     "iob_rvalid_o": ".iob_rvalid_o(slaves_resp[`RVALID(`/*<InstanceName>*/)])",
-    "trap_o": ".trap_o(trap_o[0])",
+    "trap_o": ".trap_o(/*<InstanceName>*/_trap_o)",
     "axi_awid_o": ".axi_awid_o          (axi_awid_o             [/*<extmem_conn_num>*/*AXI_ID_W       +:/*<bus_size>*/*AXI_ID_W])",
     "axi_awaddr_o": ".axi_awaddr_o      (internal_axi_awaddr_o  [/*<extmem_conn_num>*/*AXI_ADDR_W     +:/*<bus_size>*/*AXI_ADDR_W])",
     "axi_awlen_o": ".axi_awlen_o        (axi_awlen_o            [/*<extmem_conn_num>*/*AXI_LEN_W      +:/*<bus_size>*/*AXI_LEN_W])",

--- a/scripts/submodule_utils.py
+++ b/scripts/submodule_utils.py
@@ -27,43 +27,43 @@ reserved_signals = {
     "iob_ready_o": ".iob_ready_o(slaves_resp[`READY(`/*<InstanceName>*/)])",
     "iob_rvalid_o": ".iob_rvalid_o(slaves_resp[`RVALID(`/*<InstanceName>*/)])",
     "trap_o": ".trap_o(trap_o[0])",
-    "axi_awid_o": ".axi_awid_o          (axi_awid_o    [AXI_ID_W-1:0])",
-    "axi_awaddr_o": ".axi_awaddr_o      (axi_awaddr_o  [AXI_ADDR_W-1:0])",
-    "axi_awlen_o": ".axi_awlen_o        (axi_awlen_o   [AXI_LEN_W-1:0])",
-    "axi_awsize_o": ".axi_awsize_o      (axi_awsize_o  [3-1:0])",
-    "axi_awburst_o": ".axi_awburst_o    (axi_awburst_o [2-1:0])",
-    "axi_awlock_o": ".axi_awlock_o      (axi_awlock_o  [2-1:0])",
-    "axi_awcache_o": ".axi_awcache_o    (axi_awcache_o [4-1:0])",
-    "axi_awprot_o": ".axi_awprot_o      (axi_awprot_o  [3-1:0])",
-    "axi_awqos_o": ".axi_awqos_o        (axi_awqos_o   [4-1:0])",
-    "axi_awvalid_o": ".axi_awvalid_o    (axi_awvalid_o [1-1:0])",
-    "axi_awready_i": ".axi_awready_i    (axi_awready_i [1-1:0])",
-    "axi_wdata_o": ".axi_wdata_o        (axi_wdata_o   [AXI_DATA_W-1:0])",
-    "axi_wstrb_o": ".axi_wstrb_o        (axi_wstrb_o   [(AXI_DATA_W/8)-1:0])",
-    "axi_wlast_o": ".axi_wlast_o        (axi_wlast_o   [1-1:0])",
-    "axi_wvalid_o": ".axi_wvalid_o      (axi_wvalid_o  [1-1:0])",
-    "axi_wready_i": ".axi_wready_i      (axi_wready_i  [1-1:0])",
-    "axi_bid_i": ".axi_bid_i            (axi_bid_i     [AXI_ID_W-1:0])",
-    "axi_bresp_i": ".axi_bresp_i        (axi_bresp_i   [2-1:0])",
-    "axi_bvalid_i": ".axi_bvalid_i      (axi_bvalid_i  [1-1:0])",
-    "axi_bready_o": ".axi_bready_o      (axi_bready_o  [1-1:0])",
-    "axi_arid_o": ".axi_arid_o          (axi_arid_o    [AXI_ID_W-1:0])",
-    "axi_araddr_o": ".axi_araddr_o      (axi_araddr_o  [AXI_ADDR_W-1:0])",
-    "axi_arlen_o": ".axi_arlen_o        (axi_arlen_o   [AXI_LEN_W-1:0])",
-    "axi_arsize_o": ".axi_arsize_o      (axi_arsize_o  [3-1:0])",
-    "axi_arburst_o": ".axi_arburst_o    (axi_arburst_o [2-1:0])",
-    "axi_arlock_o": ".axi_arlock_o      (axi_arlock_o  [2-1:0])",
-    "axi_arcache_o": ".axi_arcache_o    (axi_arcache_o [4-1:0])",
-    "axi_arprot_o": ".axi_arprot_o      (axi_arprot_o  [3-1:0])",
-    "axi_arqos_o": ".axi_arqos_o        (axi_arqos_o   [4-1:0])",
-    "axi_arvalid_o": ".axi_arvalid_o    (axi_arvalid_o [1-1:0])",
-    "axi_arready_i": ".axi_arready_i    (axi_arready_i [1-1:0])",
-    "axi_rid_i": ".axi_rid_i            (axi_rid_i     [AXI_ID_W-1:0])",
-    "axi_rdata_i": ".axi_rdata_i        (axi_rdata_i   [AXI_DATA_W-1:0])",
-    "axi_rresp_i": ".axi_rresp_i        (axi_rresp_i   [2-1:0])",
-    "axi_rlast_i": ".axi_rlast_i        (axi_rlast_i   [1-1:0])",
-    "axi_rvalid_i": ".axi_rvalid_i      (axi_rvalid_i  [1-1:0])",
-    "axi_rready_o": ".axi_rready_o      (axi_rready_o  [1-1:0])",
+    "axi_awid_o": ".axi_awid_o          (axi_awid_o             [/*<extmem_conn_num>*/*AXI_ID_W       +:/*<bus_size>*/*AXI_ID_W])",
+    "axi_awaddr_o": ".axi_awaddr_o      (internal_axi_awaddr_o  [/*<extmem_conn_num>*/*AXI_ADDR_W     +:/*<bus_size>*/*AXI_ADDR_W])",
+    "axi_awlen_o": ".axi_awlen_o        (axi_awlen_o            [/*<extmem_conn_num>*/*AXI_LEN_W      +:/*<bus_size>*/*AXI_LEN_W])",
+    "axi_awsize_o": ".axi_awsize_o      (axi_awsize_o           [/*<extmem_conn_num>*/*3              +:/*<bus_size>*/*3])",
+    "axi_awburst_o": ".axi_awburst_o    (axi_awburst_o          [/*<extmem_conn_num>*/*2              +:/*<bus_size>*/*2])",
+    "axi_awlock_o": ".axi_awlock_o      (axi_awlock_o           [/*<extmem_conn_num>*/*2              +:/*<bus_size>*/*2])",
+    "axi_awcache_o": ".axi_awcache_o    (axi_awcache_o          [/*<extmem_conn_num>*/*4              +:/*<bus_size>*/*4])",
+    "axi_awprot_o": ".axi_awprot_o      (axi_awprot_o           [/*<extmem_conn_num>*/*3              +:/*<bus_size>*/*3])",
+    "axi_awqos_o": ".axi_awqos_o        (axi_awqos_o            [/*<extmem_conn_num>*/*4              +:/*<bus_size>*/*4])",
+    "axi_awvalid_o": ".axi_awvalid_o    (axi_awvalid_o          [/*<extmem_conn_num>*/*1              +:/*<bus_size>*/*1])",
+    "axi_awready_i": ".axi_awready_i    (axi_awready_i          [/*<extmem_conn_num>*/*1              +:/*<bus_size>*/*1])",
+    "axi_wdata_o": ".axi_wdata_o        (axi_wdata_o            [/*<extmem_conn_num>*/*AXI_DATA_W     +:/*<bus_size>*/*AXI_DATA_W])",
+    "axi_wstrb_o": ".axi_wstrb_o        (axi_wstrb_o            [/*<extmem_conn_num>*/*(AXI_DATA_W/8) +:/*<bus_size>*/*(AXI_DATA_W/8)])",
+    "axi_wlast_o": ".axi_wlast_o        (axi_wlast_o            [/*<extmem_conn_num>*/*1              +:/*<bus_size>*/*1])",
+    "axi_wvalid_o": ".axi_wvalid_o      (axi_wvalid_o           [/*<extmem_conn_num>*/*1              +:/*<bus_size>*/*1])",
+    "axi_wready_i": ".axi_wready_i      (axi_wready_i           [/*<extmem_conn_num>*/*1              +:/*<bus_size>*/*1])",
+    "axi_bid_i": ".axi_bid_i            (axi_bid_i              [/*<extmem_conn_num>*/*AXI_ID_W       +:/*<bus_size>*/*AXI_ID_W])",
+    "axi_bresp_i": ".axi_bresp_i        (axi_bresp_i            [/*<extmem_conn_num>*/*2              +:/*<bus_size>*/*2])",
+    "axi_bvalid_i": ".axi_bvalid_i      (axi_bvalid_i           [/*<extmem_conn_num>*/*1              +:/*<bus_size>*/*1])",
+    "axi_bready_o": ".axi_bready_o      (axi_bready_o           [/*<extmem_conn_num>*/*1              +:/*<bus_size>*/*1])",
+    "axi_arid_o": ".axi_arid_o          (axi_arid_o             [/*<extmem_conn_num>*/*AXI_ID_W       +:/*<bus_size>*/*AXI_ID_W])",
+    "axi_araddr_o": ".axi_araddr_o      (internal_axi_araddr_o  [/*<extmem_conn_num>*/*AXI_ADDR_W     +:/*<bus_size>*/*AXI_ADDR_W])",
+    "axi_arlen_o": ".axi_arlen_o        (axi_arlen_o            [/*<extmem_conn_num>*/*AXI_LEN_W      +:/*<bus_size>*/*AXI_LEN_W])",
+    "axi_arsize_o": ".axi_arsize_o      (axi_arsize_o           [/*<extmem_conn_num>*/*3              +:/*<bus_size>*/*3])",
+    "axi_arburst_o": ".axi_arburst_o    (axi_arburst_o          [/*<extmem_conn_num>*/*2              +:/*<bus_size>*/*2])",
+    "axi_arlock_o": ".axi_arlock_o      (axi_arlock_o           [/*<extmem_conn_num>*/*2              +:/*<bus_size>*/*2])",
+    "axi_arcache_o": ".axi_arcache_o    (axi_arcache_o          [/*<extmem_conn_num>*/*4              +:/*<bus_size>*/*4])",
+    "axi_arprot_o": ".axi_arprot_o      (axi_arprot_o           [/*<extmem_conn_num>*/*3              +:/*<bus_size>*/*3])",
+    "axi_arqos_o": ".axi_arqos_o        (axi_arqos_o            [/*<extmem_conn_num>*/*4              +:/*<bus_size>*/*4])",
+    "axi_arvalid_o": ".axi_arvalid_o    (axi_arvalid_o          [/*<extmem_conn_num>*/*1              +:/*<bus_size>*/*1])",
+    "axi_arready_i": ".axi_arready_i    (axi_arready_i          [/*<extmem_conn_num>*/*1              +:/*<bus_size>*/*1])",
+    "axi_rid_i": ".axi_rid_i            (axi_rid_i              [/*<extmem_conn_num>*/*AXI_ID_W       +:/*<bus_size>*/*AXI_ID_W])",
+    "axi_rdata_i": ".axi_rdata_i        (axi_rdata_i            [/*<extmem_conn_num>*/*AXI_DATA_W     +:/*<bus_size>*/*AXI_DATA_W])",
+    "axi_rresp_i": ".axi_rresp_i        (axi_rresp_i            [/*<extmem_conn_num>*/*2              +:/*<bus_size>*/*2])",
+    "axi_rlast_i": ".axi_rlast_i        (axi_rlast_i            [/*<extmem_conn_num>*/*1              +:/*<bus_size>*/*1])",
+    "axi_rvalid_i": ".axi_rvalid_i      (axi_rvalid_i           [/*<extmem_conn_num>*/*1              +:/*<bus_size>*/*1])",
+    "axi_rready_o": ".axi_rready_o      (axi_rready_o           [/*<extmem_conn_num>*/*1              +:/*<bus_size>*/*1])",
 }
 
 
@@ -403,12 +403,12 @@ class if_gen_hack_list:
         )
 
 
-def if_gen_interface(interface_name, port_prefix):
+def if_gen_interface(interface_name, port_prefix, bus_size=1):
     if_gen.create_signal_table(interface_name)
     # Create a virtual file object
     virtual_file_obj = if_gen_hack_list()
     # Tell if_gen to write ports in virtual file object
-    if_gen.write_vs_contents(interface_name, "", port_prefix, virtual_file_obj)
+    if_gen.write_vs_contents(interface_name, "", port_prefix, virtual_file_obj, bus_size=bus_size)
     # Extract port list from virtual file object
     return virtual_file_obj.port_list
 


### PR DESCRIPTION
This PR includes changes required for modifications in PR https://github.com/IObundle/iob-soc/pull/564

- Update reserved signals for ext_mem.
   This will **break** iob-soc based systems using ext_mem that do not have the changes from https://github.com/IObundle/iob-soc/pull/564
- Add `N_INTERCONNECT_SLAVES` parameter to Vivado tcl scripts and Makefiles.
- Copy LIB files before repository sources.
  Now, the `_run_setup()` method of the `iob_module` manages the copy sequence. The LIB files are copied first, followed by the copy of repository files.
- Only copy `hardware/src` and `software` directories from submodules.
  No longer copies `hardware/simulation`, `hardware/fpga`, `hardware/lint`... from submodules.