### PR TITLE
Copy LIB files before repository sources.

### DIFF
--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -29,11 +29,6 @@ def setup(python_module, no_overlap=False, disable_file_gen=False):
     top = python_module.name
     build_dir = python_module.build_dir
 
-    #
-    # Setup flows
-    #
-    build_srcs.flows_setup(python_module)
-
     # Auto-add 'VERSION' macro if it doesn't exist
     for macro in confs:
         if macro["name"] == "VERSION":
@@ -118,17 +113,18 @@ def setup(python_module, no_overlap=False, disable_file_gen=False):
         # Generate sw
         #
         if "emb" in python_module.flows:
+            os.makedirs(build_dir + "/software/src", exist_ok=True)
             if regs:
                 mkregs_obj.write_swheader(
-                    reg_table, python_module.build_dir + "/software/src", top
+                    reg_table, build_dir + "/software/src", top
                 )
                 mkregs_obj.write_swcode(
-                    reg_table, python_module.build_dir + "/software/src", top
+                    reg_table, build_dir + "/software/src", top
                 )
                 mkregs_obj.write_swheader(
-                    reg_table, python_module.build_dir + "/software/src", top
+                    reg_table, build_dir + "/software/src", top
                 )
-            mk_conf.conf_h(confs, top, python_module.build_dir + "/software/src")
+            mk_conf.conf_h(confs, top, build_dir + "/software/src")
 
         #
         # Generate TeX


### PR DESCRIPTION
Cherry-picked commit 6c70fee032c34103e0961c92dc602c7a15b4370f from python-setup branch.

- Change order of file copy during setup process; Previously, the files from the repo were copied first, and then the `setup()` function of LIB copied the LIB files and overriden files any in the build_dir. Now, `_run_setup()` method of the `iob_module` manages the copy sequence. The LIB files are copied first, followed by the copy of repository files.
- Only call *_setup.py files from the repo after copying every file from LIB and repo.
- Only copy `hardware/src` and `software` directories from submodules. No longer copies `hardware/simulation`, `hardware/fpga`, `hardware/lint`... from submodules.