### PR TITLE
Improve `verilog-lint.sh` script.

### DIFF
--- a/scripts/submodule_utils.py
+++ b/scripts/submodule_utils.py
@@ -634,13 +634,13 @@ def get_periphs_id_as_macros(peripherals_list):
 # Return amount of system peripherals
 def get_n_periphs(peripherals_list):
     # +1 because the internal memory is not in the peripherals_list. int_mem is implicit peripheral. It is treated as a peripheral by the internal signals. (might change in the future)
-    return str(len(peripherals_list)+1)
+    return str(len(peripherals_list) + 1)
 
 
 # Return bus width required to address all peripherals
 def get_n_periphs_w(peripherals_list):
     # +1 because the internal memory is not in the peripherals_list. int_mem is implicit peripheral. It is treated as a peripheral by the internal signals. (might change in the future)
-    i = len(peripherals_list)+1
+    i = len(peripherals_list) + 1
     if not i:
         return str(0)
     else:

--- a/scripts/verible-lint.rules
+++ b/scripts/verible-lint.rules
@@ -6,3 +6,4 @@
 -explicit-task-lifetime
 -unpacked-dimensions-range-ordering
 -always-comb
+-module-filename

--- a/scripts/verilog-lint.sh
+++ b/scripts/verilog-lint.sh
@@ -29,7 +29,7 @@ done
 total_files_combined=$idx
 
 # Lint the temporary combined file and remove it if successful
-ERROR_STR=`verible-verilog-lint  --rules_config $IOB_LIB_PATH/verible-lint.rules $TMP_FILENAME && rm $TMP_FILENAME || true`
+ERROR_STR=`verible-verilog-lint --rules_config $IOB_LIB_PATH/verible-lint.rules $TMP_FILENAME 2>&1 && rm $TMP_FILENAME || true`
 #echo "'$ERROR_STR'" #DEBUG
 
 # Exit if there was no error

--- a/scripts/verilog-lint.sh
+++ b/scripts/verilog-lint.sh
@@ -1,6 +1,16 @@
 #!/usr/bin/env bash
 # run the command below for all files given as command line arguments
 set -e
-cat $@ > /tmp/combined
-verible-verilog-lint  --rules_config $IOB_LIB_PATH/verible-lint.rules /tmp/combined
-rm /tmp/combined
+
+TMP_FILENAME=~linter_files_combined.tmp
+
+rm -f $TMP_FILENAME
+for file in $@;
+do
+  echo -e "\n////////////////////////////////////////////////////////////////////" >> $TMP_FILENAME
+  echo "// File $file" >> $TMP_FILENAME
+  echo -e ////////////////////////////////////////////////////////////////////"\n\n" >> $TMP_FILENAME
+  cat $file >> $TMP_FILENAME
+done
+# Lint the temporary combined file and remove it if successful
+verible-verilog-lint  --rules_config $IOB_LIB_PATH/verible-lint.rules $TMP_FILENAME && rm $TMP_FILENAME

--- a/scripts/verilog-lint.sh
+++ b/scripts/verilog-lint.sh
@@ -5,12 +5,54 @@ set -e
 TMP_FILENAME=~linter_files_combined.tmp
 
 rm -f $TMP_FILENAME
+
+# Create array of tuples to store filenames and starting line numbers
+declare -A files_linenumber
+
+idx=0
+# Combine all files into one file, separating them with a comment, and creating an array for each file
 for file in $@;
 do
+  # Add comment to specify original file name
   echo -e "\n////////////////////////////////////////////////////////////////////" >> $TMP_FILENAME
-  echo "// File $file" >> $TMP_FILENAME
+  echo "// Original file $file" >> $TMP_FILENAME
   echo -e ////////////////////////////////////////////////////////////////////"\n\n" >> $TMP_FILENAME
+  
+  # Store this filename and corresponding start line number into a dictionary
+  files_linenumber[$idx,0]="$file"
+  files_linenumber[$idx,1]=`wc -l $TMP_FILENAME | cut -d' ' -f1`
+  idx=$(($idx+1))
+
+  # Add file content
   cat $file >> $TMP_FILENAME
 done
+total_files_combined=$idx
+
 # Lint the temporary combined file and remove it if successful
-verible-verilog-lint  --rules_config $IOB_LIB_PATH/verible-lint.rules $TMP_FILENAME && rm $TMP_FILENAME
+ERROR_STR=`verible-verilog-lint  --rules_config $IOB_LIB_PATH/verible-lint.rules $TMP_FILENAME && (rm $TMP_FILENAME; exit 0) || true`
+#echo "'$ERROR_STR'" #DEBUG
+
+# For each error line, find the correct original file
+while IFS= read -r line; do
+  #echo "Processing line: $line" #DEBUG
+  LINE_NUM=`echo $line | cut -d: -f2`
+  ERROR_LINE=`echo $line | cut -d: -f3-`
+  #echo "$LINE_NUM $ERROR_LINE" #DEBUG
+  # Find which file contains the current line number
+  for idx in `seq 0 $(($total_files_combined-1))`;
+  do
+    #echo -e "\n\n$idx ${files_linenumber[$idx,0]} ${files_linenumber[$idx,1]}" #DEBUG
+    
+    # If this is the last file
+    # or the line number of the next file is greater than the current line number
+    # then the current file has the error.
+    if [ $idx -eq $(($total_files_combined-1)) ] || [ "${files_linenumber[$(($idx+1)),1]}" -gt "$LINE_NUM" ]; then
+      #echo "Error is in file: ${files_linenumber[$(($idx)),0]}" #DEBUG
+      # Print error line with format: 'Error: <filename>:<linenumber>:<message>'
+      echo "Error: ${files_linenumber[$(($idx)),0]}:$(($LINE_NUM-${files_linenumber[$(($idx)),1]})):$ERROR_LINE"
+      break
+    fi
+  done
+done <<< "$ERROR_STR"
+
+exit 1

--- a/setup.mk
+++ b/setup.mk
@@ -110,6 +110,7 @@ endif
 clean:
 	-@if [ -f $(BUILD_DIR)/Makefile ]; then make -C $(BUILD_DIR) clean; fi
 	@rm -rf $(BUILD_DIR)
+	@rm -f ~*
 ifneq ($(wildcard config_delivery.mk),)
 	make delivery-clean
 endif


### PR DESCRIPTION
[e7c5eb8]: Improve combined file. 
This commit improves the combined file generated.
- The new combined file will have the original file names inside comments separating the file contents.
- The new combined file won't be deleted if there is an error to allow analyzing its contents.
- The new combined file is "~linter_files_combined.tmp". This naming scheme follows one of the conventions mentioned here: https://docs.storagemadeeasy.com/incompatiblecharacters

[7372282]: Parse error message to print original file name. 
This commit improves the error messaged printed by the `verilog-lint.sh` script.
- Error messages of the combined file are now parsed and auto-converted to the original file name and line number that contains the error.

[3d7b06b]
This commit merges the upstream and fixes bugs.
- Merge upstream 
- Fix bug in `VFILES` list of `setup.mk` that prevented it from finding any Verilog sources.
- Fix bug in `verilog-lint.sh` script to exit normally when there are no linter errors.