### PR TITLE
fix LIB tests, improve format targets, format python script, add div modules

### DIFF
--- a/hardware/modules/div/iob_div_pipe/iob_div_pipe.py
+++ b/hardware/modules/div/iob_div_pipe/iob_div_pipe.py
@@ -1,0 +1,61 @@
+import os
+import shutil
+
+from iob_module import iob_module
+from setup import setup
+
+
+class iob_div_pipe(iob_module):
+    name = "iob_div_pipe"
+    version = "V0.10"
+    flows = "sim"
+    setup_dir = os.path.dirname(__file__)
+
+    @classmethod
+    def _run_setup(cls):
+        super()._run_setup()
+
+        # Setup dependencies
+
+        if cls.is_top_module:
+            # Setup flows of this core using LIB setup function
+            setup(cls, disable_file_gen=True)
+
+            # Copy testbench if this is the top module
+            shutil.copyfile(
+                os.path.join(cls.setup_dir, "iob_div_pipe_tb.v"),
+                os.path.join(
+                    cls.build_dir, "hardware/simulation/src", "iob_div_pipe_tb.v"
+                ),
+            )
+
+    # Copy sources of this module to the build directory
+    @classmethod
+    def _copy_srcs(cls):
+        out_dir = cls.get_purpose_dir(cls._setup_purpose[-1])
+        # Copy source to build directory
+        shutil.copyfile(
+            os.path.join(cls.setup_dir, "iob_div_pipe.v"),
+            os.path.join(cls.build_dir, out_dir, "iob_div_pipe.v"),
+        )
+        shutil.copyfile(
+            os.path.join(cls.setup_dir, "iob_div_slice.v"),
+            os.path.join(cls.build_dir, out_dir, "iob_div_slice.v"),
+        )
+
+        # Ensure sources of other purposes are deleted (except software)
+        # Check that latest purpose is hardware
+        if cls._setup_purpose[-1] == "hardware" and len(cls._setup_purpose) > 1:
+            # Purposes that have been setup previously
+            for purpose in [x for x in cls._setup_purpose[:-1] if x != "software"]:
+                # Delete sources for this purpose
+                os.remove(
+                    os.path.join(
+                        cls.build_dir, cls.PURPOSE_DIRS[purpose], "iob_div_pipe.v"
+                    )
+                )
+                os.remove(
+                    os.path.join(
+                        cls.build_dir, cls.PURPOSE_DIRS[purpose], "iob_div_slice.v"
+                    )
+                )

--- a/hardware/modules/div/iob_div_pipe/iob_div_pipe.v
+++ b/hardware/modules/div/iob_div_pipe/iob_div_pipe.v
@@ -1,0 +1,50 @@
+`timescale 1ns / 1ps
+
+module iob_div_pipe # (
+                   parameter DATA_W = 32,
+                   parameter OPERS_PER_STAGE = 8
+                   )
+   (
+	input               clk_i,
+
+	input [DATA_W-1:0]  dividend_i,
+	input [DATA_W-1:0]  divisor_i,
+
+	output [DATA_W-1:0] quotient_o,
+	output [DATA_W-1:0] remainder_o
+	);
+
+   wire [(DATA_W+1)*DATA_W-1:0] dividend_int;
+   wire [(DATA_W+1)*DATA_W-1:0] divisor_int;
+   wire [(DATA_W+1)*DATA_W-1:0] quotient_int;
+
+   assign dividend_int[DATA_W-1:0] = dividend_i;
+   assign divisor_int[DATA_W-1:0]  = divisor_i;
+   assign quotient_int[DATA_W-1:0] = {DATA_W{1'b0}};
+
+   genvar                       k;
+   generate
+      for(k=1; k <= DATA_W; k=k+1) begin : div_slice_array_el
+	     iob_div_slice # (
+                      .DATA_W(DATA_W),
+                      .STAGE(k),
+                      .OUTPUT_REG(!(k%OPERS_PER_STAGE))
+                      )
+         uut (
+			  .clk_i(clk_i),
+
+			  .dividend_i(dividend_int[k*DATA_W-1 -: DATA_W]),
+			  .divisor_i(divisor_int[k*DATA_W-1 -: DATA_W]),
+			  .quotient_i(quotient_int[k*DATA_W-1 -: DATA_W]),
+
+			  .dividend_o(dividend_int[(k+1)*DATA_W-1 -: DATA_W]),
+			  .divisor_o(divisor_int[(k+1)*DATA_W-1 -: DATA_W]),
+			  .quotient_o(quotient_int[(k+1)*DATA_W-1 -: DATA_W])
+			  );
+      end
+   endgenerate
+
+   assign quotient_o  = quotient_int[(DATA_W+1)*DATA_W-1 -: DATA_W];
+   assign remainder_o = dividend_int[(DATA_W+1)*DATA_W-1 -: DATA_W];
+
+endmodule

--- a/hardware/modules/div/iob_div_pipe/iob_div_pipe_tb.v
+++ b/hardware/modules/div/iob_div_pipe/iob_div_pipe_tb.v
@@ -1,0 +1,94 @@
+`timescale 1ns / 1ps
+
+`define CLK_FREQ (100000000)
+
+module iob_div_pipe_tb;
+
+   parameter clk_frequency = `CLK_FREQ;
+   parameter clk_period = 1e9/clk_frequency; //ns
+
+   parameter DATA_W = 32;
+   parameter OPERS_PER_STAGE = 8;
+
+   parameter TEST_SZ = 100;
+
+   reg clk;
+
+   wire [DATA_W-1:0] dividend;
+   wire [DATA_W-1:0] divisor;
+   wire [DATA_W-1:0] quotient;
+   wire [DATA_W-1:0] remainder;
+
+   wire [DATA_W-1:0] q;
+   wire [DATA_W-1:0] r;
+
+   reg [DATA_W-1:0]  dividend_in [0:TEST_SZ-1];
+   reg [DATA_W-1:0]  divisor_in [0:TEST_SZ-1];
+   reg [DATA_W-1:0]  quotient_out [0:TEST_SZ-1];
+   reg [DATA_W-1:0]  remainder_out [0:TEST_SZ-1];
+
+   integer           i, j;
+
+   iob_div_pipe # (
+               .DATA_W(DATA_W),
+               .OPERS_PER_STAGE(OPERS_PER_STAGE)
+               )
+   uut (
+		.clk_i(clk),
+
+		.dividend_i(dividend),
+		.divisor_i(divisor),
+
+		.quotient_o(quotient),
+		.remainder_o(remainder)
+		);
+
+   initial begin
+
+`ifdef VCD
+      $dumpfile("div_pipe.vcd");
+      $dumpvars();
+`endif
+
+      clk = 0;
+
+      j=0;
+
+      // generate test data
+      for (i=0; i < TEST_SZ; i=i+1) begin
+	     dividend_in[i] = $random%(2**(DATA_W-1));
+	     divisor_in[i] = $random%(2**(DATA_W-1));
+	     quotient_out[i] = dividend_in[i] / divisor_in[i];
+	     remainder_out[i] = dividend_in[i] % divisor_in[i];
+      end
+
+      #((TEST_SZ+DATA_W/OPERS_PER_STAGE)*clk_period);
+
+      $display("Test completed successfully");
+      $finish;
+   end
+
+   always 
+     #(clk_period/2) clk = ~clk;   
+
+   always @ (posedge clk) begin
+      j <= j+1;
+   end
+
+   // assign inputs
+   assign dividend = dividend_in[j];
+   assign divisor = divisor_in[j];
+
+   // show expected results
+   assign q = quotient_out[j];
+   assign r = remainder_out[j];
+
+   always @ (negedge clk) begin
+      if(j >= DATA_W/OPERS_PER_STAGE && (quotient != quotient_out[j-DATA_W/OPERS_PER_STAGE] ||
+                                         remainder != remainder_out[j-DATA_W/OPERS_PER_STAGE])) begin
+	     $display("Test failed at %d", $time);
+	     $finish;
+      end
+   end
+
+endmodule

--- a/hardware/modules/div/iob_div_pipe/iob_div_slice.v
+++ b/hardware/modules/div/iob_div_pipe/iob_div_slice.v
@@ -1,0 +1,42 @@
+`timescale 1ns / 1ps
+
+module iob_div_slice # (
+                    parameter DATA_W = 32,
+                    parameter STAGE = 1,
+                    parameter OUTPUT_REG = 1
+                    )
+   (
+	input                   clk_i,
+
+	input [DATA_W-1:0]      dividend_i,
+	input [DATA_W-1:0]      divisor_i,
+	input [DATA_W-1:0]      quotient_i,
+
+	output reg [DATA_W-1:0] dividend_o,
+	output reg [DATA_W-1:0] divisor_o,
+	output reg [DATA_W-1:0] quotient_o
+	);
+
+   wire                     sub_sign;
+   wire [2*DATA_W-STAGE:0]  sub_res;
+
+   assign sub_res  = {{DATA_W{1'b0}}, dividend_i} - {{STAGE{1'b0}}, divisor_i, {(DATA_W-STAGE){1'b0}}};
+   assign sub_sign = sub_res[2*DATA_W-STAGE];
+
+   generate
+      if (OUTPUT_REG) begin
+         always @ (posedge clk_i) begin
+            dividend_o <= (sub_sign)? dividend_i: sub_res[DATA_W-1:0];
+            quotient_o <= quotient_i << 1 | {{(DATA_W-1){1'b0}}, ~sub_sign};
+            divisor_o  <= divisor_i;
+         end
+      end else begin
+         always @ * begin
+            dividend_o = (sub_sign)? dividend_i: sub_res[DATA_W-1:0];
+            quotient_o = quotient_i << 1 | {{(DATA_W-1){1'b0}}, ~sub_sign};
+            divisor_o  = divisor_i;
+         end
+      end
+   endgenerate
+
+endmodule

--- a/hardware/modules/div/iob_div_subshift/iob_div_subshift.py
+++ b/hardware/modules/div/iob_div_subshift/iob_div_subshift.py
@@ -1,0 +1,55 @@
+import os
+import shutil
+
+from iob_module import iob_module
+from setup import setup
+
+from iob_reg import iob_reg
+
+
+class iob_div_subshift(iob_module):
+    name = "iob_div_subshift"
+    version = "V0.10"
+    flows = "sim"
+    setup_dir = os.path.dirname(__file__)
+
+    @classmethod
+    def _run_setup(cls):
+        super()._run_setup()
+
+        # Setup dependencies
+        iob_reg.setup()
+
+        if cls.is_top_module:
+            # Setup flows of this core using LIB setup function
+            setup(cls, disable_file_gen=True)
+
+            # Copy testbench if this is the top module
+            shutil.copyfile(
+                os.path.join(cls.setup_dir, "iob_div_subshift_tb.v"),
+                os.path.join(
+                    cls.build_dir, "hardware/simulation/src", "iob_div_subshift_tb.v"
+                ),
+            )
+
+    # Copy sources of this module to the build directory
+    @classmethod
+    def _copy_srcs(cls):
+        out_dir = cls.get_purpose_dir(cls._setup_purpose[-1])
+        # Copy source to build directory
+        shutil.copyfile(
+            os.path.join(cls.setup_dir, "iob_div_subshift.v"),
+            os.path.join(cls.build_dir, out_dir, "iob_div_subshift.v"),
+        )
+
+        # Ensure sources of other purposes are deleted (except software)
+        # Check that latest purpose is hardware
+        if cls._setup_purpose[-1] == "hardware" and len(cls._setup_purpose) > 1:
+            # Purposes that have been setup previously
+            for purpose in [x for x in cls._setup_purpose[:-1] if x != "software"]:
+                # Delete sources for this purpose
+                os.remove(
+                    os.path.join(
+                        cls.build_dir, cls.PURPOSE_DIRS[purpose], "iob_div_subshift.v"
+                    )
+                )

--- a/hardware/modules/div/iob_div_subshift/iob_div_subshift.v
+++ b/hardware/modules/div/iob_div_subshift/iob_div_subshift.v
@@ -1,0 +1,99 @@
+`timescale 1ns / 1ps
+
+module iob_div_subshift
+  # (
+     parameter DATA_W = 32
+     )
+   (
+    input               clk_i,
+    input               arst_i,
+    input               cke_i,
+    // TODO add cke_i
+    input               start_i,
+    output reg          done_o,
+
+    input [DATA_W-1:0]  dividend_i,
+    input [DATA_W-1:0]  divisor_i,
+    output [DATA_W-1:0] quotient_o,
+    output [DATA_W-1:0] remainder_o
+    );
+
+   //dividend/quotient/remainder register
+   reg [2*DATA_W:0]     dqr_nxt;
+   wire [2*DATA_W:0]     dqr_reg;
+
+   iob_reg #(
+      .DATA_W (2*DATA_W+1),
+      .RST_VAL(1'b0)
+   ) dqr_reg0 (
+      .clk_i (clk_i),
+      .arst_i(arst_i),
+      .cke_i (cke_i),
+
+      .data_i(dqr_nxt),
+      .data_o(dqr_reg)
+   );
+
+   //divisor register
+   reg [DATA_W-1:0]     divisor_nxt;
+   wire [DATA_W-1:0]    divisor_reg;
+
+   iob_reg #(
+      .DATA_W (DATA_W),
+      .RST_VAL(1'b0)
+   ) div_reg0 (
+      .clk_i (clk_i),
+      .arst_i(arst_i),
+      .cke_i (cke_i),
+
+      .data_i(divisor_nxt),
+      .data_o(divisor_reg)
+   );
+   
+   wire [DATA_W-1:0]    subtraend = dqr_reg[2*DATA_W-2-:DATA_W];
+   reg [DATA_W:0]       tmp;
+
+   //output quotient and remainder
+   assign quotient_o = dqr_reg[DATA_W-1:0];
+   assign remainder_o = dqr_reg[2*DATA_W-1:DATA_W];
+   
+                        
+   //
+   //PROGRAM
+   //
+
+   reg [$clog2(DATA_W+2):0] pc, pc_nxt;  //program counter
+   always @(posedge clk_i, posedge arst_i) if(arst_i) pc <= 1'b0; else pc <= pc_nxt;
+
+   always @* begin
+      pc_nxt = pc+1'b1;
+      dqr_nxt = dqr_reg;
+      divisor_nxt = divisor_i;
+      done_o = 1'b1;
+      
+      case (pc)
+	0: begin //wait for start, load operands and do it
+           if(!start_i) begin
+              pc_nxt = pc;
+           end else begin
+              divisor_nxt = divisor_i;
+              dqr_nxt = {{DATA_W{1'b0}}, dividend_i};
+	   end
+        end
+	
+        DATA_W+1: begin
+           pc_nxt = 1'b0;
+        end
+	
+        default: begin //shift and subtract
+           done_o = 1'b0;
+	   tmp = {1'b0, subtraend} - {1'b0, divisor_reg};
+           if(~tmp[DATA_W])
+             dqr_nxt = {tmp, dqr_reg[DATA_W-2 : 0], 1'b1};
+           else 
+             dqr_nxt = {dqr_reg[2*DATA_W-2 : 0], 1'b0};
+        end
+      endcase // case (pc)
+   end
+   
+endmodule

--- a/hardware/modules/div/iob_div_subshift/iob_div_subshift_tb.v
+++ b/hardware/modules/div/iob_div_subshift/iob_div_subshift_tb.v
@@ -1,0 +1,91 @@
+`timescale 1ns / 1ps
+
+`define CLK_FREQ (100000000)
+
+module iob_div_subshift_tb;
+
+   parameter clk_frequency = `CLK_FREQ;
+   parameter clk_period = 1e9/clk_frequency; //ns
+   parameter DATA_W = 8;
+   parameter TEST_SZ = 1000;
+
+   reg clk = 0;
+   reg rst = 0;
+   reg start = 0;
+   wire done;
+
+   //data
+   reg [DATA_W-1:0]  dividend [0:TEST_SZ-1];
+   reg [DATA_W-1:0]  divisor [0:TEST_SZ-1];
+   reg [DATA_W-1:0]  quotient [0:TEST_SZ-1];
+   reg [DATA_W-1:0]  remainder [0:TEST_SZ-1];
+
+   //core outputs
+   wire [DATA_W-1:0] quotient_out;
+   wire [DATA_W-1:0] remainder_out;
+   
+   integer           i;
+
+ 
+   initial begin
+
+`ifdef VCD
+      $dumpfile("uut.vcd");
+      $dumpvars();
+`endif
+
+      // generate test data
+      for (i=0; i < TEST_SZ; i=i+1) begin
+	 dividend[i] = $random;
+	 divisor[i] = $random;
+	 quotient[i] = dividend[i] / divisor[i];
+	 remainder[i] = dividend[i] % divisor[i];
+      end
+            
+      //reset pulse
+      #100 rst = 1;
+      @(posedge clk) #1 rst = 0;
+      
+      //compute divisions
+      for (i=0; i < TEST_SZ; i=i+1) begin
+         //pulse start
+         @(posedge clk) #1 start = 1;
+         @(posedge clk) #1 start = 0;
+
+         //wait for done
+         @(posedge clk) #1;
+         while(!done)
+           @(posedge clk) #1;
+         
+         //verify results
+         if(quotient_out != quotient[i] || remainder_out != remainder[i])
+           $display ("%d / %d = %d with rem %d but got %d with rem %d", dividend[i], divisor[i], quotient[i], remainder[i], quotient_out, remainder_out);
+      end
+
+      $finish;
+
+   end
+
+   //clock
+   always #(clk_period/2) clk = ~clk;   
+
+   //instantiate unsigned divider
+   iob_div_subshift 
+     # (
+        .DATA_W(DATA_W)
+        )
+   uut 
+     (
+      .clk_i(clk),
+      .arst_i(rst),
+      .cke_i(1'b1),
+      .start_i(start),
+      .done_o(done),
+
+      .dividend_i(dividend[i]),
+      .divisor_i(divisor[i]),
+      .quotient_o(quotient_out),
+      .remainder_o(remainder_out)
+      );
+   
+endmodule

--- a/hardware/modules/div/iob_div_subshift_frac/iob_div_subshift_frac.py
+++ b/hardware/modules/div/iob_div_subshift_frac/iob_div_subshift_frac.py
@@ -1,0 +1,63 @@
+import os
+import shutil
+
+from iob_module import iob_module
+from setup import setup
+
+from iob_reg import iob_reg
+from iob_reg_e import iob_reg_e
+from iob_div_subshift import iob_div_subshift
+
+
+class iob_div_subshift_frac(iob_module):
+    name = "iob_div_subshift_frac"
+    version = "V0.10"
+    flows = "sim"
+    setup_dir = os.path.dirname(__file__)
+
+    @classmethod
+    def _run_setup(cls):
+        super()._run_setup()
+
+        # Setup dependencies
+        iob_reg.setup()
+        iob_reg_e.setup()
+        iob_div_subshift.setup()
+
+        if cls.is_top_module:
+            # Setup flows of this core using LIB setup function
+            setup(cls, disable_file_gen=True)
+
+            # Copy testbench if this is the top module
+            shutil.copyfile(
+                os.path.join(cls.setup_dir, "iob_div_subshift_frac_tb.v"),
+                os.path.join(
+                    cls.build_dir,
+                    "hardware/simulation/src",
+                    "iob_div_subshift_frac_tb.v",
+                ),
+            )
+
+    # Copy sources of this module to the build directory
+    @classmethod
+    def _copy_srcs(cls):
+        out_dir = cls.get_purpose_dir(cls._setup_purpose[-1])
+        # Copy source to build directory
+        shutil.copyfile(
+            os.path.join(cls.setup_dir, "iob_div_subshift_frac.v"),
+            os.path.join(cls.build_dir, out_dir, "iob_div_subshift_frac.v"),
+        )
+
+        # Ensure sources of other purposes are deleted (except software)
+        # Check that latest purpose is hardware
+        if cls._setup_purpose[-1] == "hardware" and len(cls._setup_purpose) > 1:
+            # Purposes that have been setup previously
+            for purpose in [x for x in cls._setup_purpose[:-1] if x != "software"]:
+                # Delete sources for this purpose
+                os.remove(
+                    os.path.join(
+                        cls.build_dir,
+                        cls.PURPOSE_DIRS[purpose],
+                        "iob_div_subshift_frac.v",
+                    )
+                )

--- a/hardware/modules/div/iob_div_subshift_frac/iob_div_subshift_frac.v
+++ b/hardware/modules/div/iob_div_subshift_frac/iob_div_subshift_frac.v
@@ -1,0 +1,124 @@
+`timescale 1ns / 1ps
+
+module iob_div_subshift_frac
+  # (
+     parameter DATA_W = 32
+     )
+   (
+    input               clk_i,
+    input               arst_i,
+    input               cke_i,
+    input               start_i,
+    output              done_o,
+
+    input [DATA_W-1:0]  dividend_i,
+    input [DATA_W-1:0]  divisor_i,
+    output [DATA_W-1:0] quotient_o,
+    output [DATA_W-1:0] remainder_o
+    );
+
+   wire [DATA_W-1:0]   divisor_reg;
+
+   iob_reg #(
+      .DATA_W (DATA_W),
+      .RST_VAL(1'b0)
+   ) divisor_reg0 (
+      .clk_i (clk_i),
+      .arst_i(arst_i),
+      .cke_i (cke_i),
+
+      .data_i(divisor_i),
+      .data_o(divisor_reg)
+   );
+   
+   //output quotient
+   wire [DATA_W-1:0]  quotient_int;
+   reg                incr; //residue   
+   assign quotient_o =  quotient_int + incr;
+
+   iob_div_subshift
+     # (
+        .DATA_W(DATA_W)
+        )
+   div_subshift0
+     (
+      .clk_i(clk_i),
+      .arst_i(arst_i),
+      .cke_i(cke_i),
+      .start_i(start_i),
+      .done_o(done_o),
+      
+      .dividend_i(dividend_i),
+      .divisor_i(divisor_i),
+      .quotient_o(quotient_int),
+      .remainder_o(remainder_o)
+      );
+
+   //residue accum
+   reg [DATA_W:0]     res_acc_nxt;
+   wire [DATA_W:0]    res_acc;
+   reg res_acc_en;
+                
+   iob_reg_e #(
+      .DATA_W (DATA_W+1),
+      .RST_VAL(1'b0)
+   ) res_acc_reg0 (
+      .clk_i (clk_i),
+      .arst_i(arst_i),
+      .cke_i (cke_i),
+      .en_i(res_acc_en),
+
+      .data_i(res_acc_nxt),
+      .data_o(res_acc)
+   );
+   
+   //pc register
+   reg [1:0] pc_nxt;
+   wire [1:0] pc;
+
+   iob_reg #(
+      .DATA_W (2),
+      .RST_VAL(1'b0)
+   ) pc_reg0 (
+      .clk_i (clk_i),
+      .arst_i(arst_i),
+      .cke_i (cke_i),
+
+      .data_i(pc_nxt),
+      .data_o(pc)
+   );
+   
+   always @* begin
+      incr=1'b0;
+      res_acc_nxt = res_acc + remainder_o;
+      res_acc_en = 1'b0;
+      pc_nxt = pc+1'b1;
+      
+      case (pc)
+        0: begin //wait for div start
+           if(!start_i)
+             pc_nxt = pc;
+        end
+
+        1: begin //wait for div done
+           if(!done_o)
+             pc_nxt = pc;
+        end
+        
+        default: begin
+           res_acc_en = 1'b1;
+           if(res_acc_nxt >= divisor_i) begin
+              incr = 1'b1;
+              res_acc_nxt = res_acc + remainder_o - divisor_i;
+           end
+           if(!start_i)
+             pc_nxt = pc;
+           else
+             pc_nxt = 1'b1;
+        end
+      endcase // case (pc)
+      
+   end
+
+   
+endmodule

--- a/hardware/modules/div/iob_div_subshift_frac/iob_div_subshift_frac_tb.v
+++ b/hardware/modules/div/iob_div_subshift_frac/iob_div_subshift_frac_tb.v
@@ -1,0 +1,95 @@
+`timescale 1ns / 1ps
+
+`define CLK_FREQ (100000000)
+
+module iob_div_subshift_frac_tb;
+
+   parameter clk_frequency = `CLK_FREQ;
+   parameter clk_period = 1e9/clk_frequency; //ns
+   parameter DATA_W = 8;
+   parameter TEST_SZ = 100;
+
+   reg clk = 0;
+   reg rst = 0;
+   reg start = 0;
+   wire done;
+
+   //data
+   reg [DATA_W-1:0]  dividend [0:TEST_SZ-1];
+   reg [DATA_W-1:0]  divisor [0:TEST_SZ-1];
+   reg [DATA_W-1:0]  quotient [0:TEST_SZ-1];
+   reg [DATA_W-1:0]  remainder [0:TEST_SZ-1];
+
+   //core outputs
+   wire [DATA_W-1:0]        quotient_out;
+   wire [DATA_W-1:0]        remainder_out;
+   
+   integer           i;
+ 
+   initial begin
+
+`ifdef VCD
+      $dumpfile("div.vcd");
+      $dumpvars();
+`endif
+
+      // generate test data
+      for (i=0; i < TEST_SZ; i=i+1) begin
+//	 dividend[i] = $random;
+//	 divisor[i] = $random;
+	 dividend[i] = 10;
+	 divisor[i] = 3;
+	 quotient[i] = dividend[i] / divisor[i];
+	 remainder[i] = dividend[i] % divisor[i];
+      end
+      
+      //reset pulse
+      #100 rst = 1;
+      @(posedge clk) #1 rst = 0;
+      
+      //compute divisions
+      for (i=0; i < TEST_SZ; i=i+1) begin
+        //pulse start
+         @(posedge clk) #1 start = 1;
+         @(posedge clk) #1 start = 0;
+
+         //wait for done
+         while(!done)
+           @(posedge clk) #1;
+         
+         //verify results
+         if(quotient_out != quotient[i] || remainder_out != remainder[i])
+           $display ("%d / %d = %d with rem %d but got %d with rem %d", dividend[i], divisor[i], quotient[i], remainder[i], quotient_out, remainder_out);
+
+         
+         #1000;
+         
+      end
+
+      $finish;
+
+   end
+
+   //clock
+   always #(clk_period/2) clk = ~clk;   
+
+   //instantiate divider
+   iob_div_subshift_frac
+     # (
+        .DATA_W(DATA_W)
+        )
+   uut 
+     (
+      .clk_i(clk),
+      .arst_i(rst),
+      .cke_i(1'b1),
+      .start_i(start),
+      .done_o(done),
+
+      .dividend_i(dividend[i]),
+      .divisor_i(divisor[i]),
+      .quotient_o(quotient_out),
+      .remainder_o(remainder_out)
+      );
+
+endmodule

--- a/hardware/modules/div/iob_div_subshift_signed/iob_div_subshift_signed.v
+++ b/hardware/modules/div/iob_div_subshift_signed/iob_div_subshift_signed.v
@@ -1,0 +1,87 @@
+`timescale 1ns / 1ps
+
+module iob_div_subshift_signed
+  # (
+     parameter DATA_W = 32
+     )
+   (
+    input               clk_i,
+    
+    input               en_i,
+    input               sign_i,
+    output reg          done_o,
+
+    input [DATA_W-1:0]  dividend_i,
+    input [DATA_W-1:0]  divisor_i,
+    output [DATA_W-1:0] quotient_o,
+    output [DATA_W-1:0] remainder_o
+    );
+
+   reg [2*DATA_W:0]     rq;
+   reg [DATA_W-1:0] 	divisor_reg;
+   reg                  divident_sign;
+   reg                  divisor_sign;
+   reg [$clog2(DATA_W+5):0] pc;  //program counter
+   wire [DATA_W-1:0] 	    subtraend = rq[2*DATA_W-2-:DATA_W];
+   reg [DATA_W:0] tmp;
+   
+   //output quotient and remainder
+   assign quotient_o = rq[DATA_W-1:0];
+   assign remainder_o = rq[2*DATA_W-1:DATA_W];
+
+   //
+   //PROGRAM
+   //
+   
+   always @(posedge clk_i) begin
+      if(en_i) begin
+         pc <= pc+1'b1;
+         
+         case (pc)
+	   0: begin //load operands and result sign
+              if(sign_i) begin
+                 divisor_reg <= divisor_i;
+                 divisor_sign <= divisor_i[DATA_W-1];
+                 rq[DATA_W-1:0] <= dividend_i[DATA_W-1]? -dividend_i: dividend_i;
+                 divident_sign <= dividend_i[DATA_W-1];
+              end else begin
+                 divisor_reg <= divisor_i;
+                 divisor_sign <= 1'b0;
+                 rq[DATA_W-1:0] <= dividend_i;
+                 divident_sign <= 1'b0;
+              end
+	   end // case: 0
+
+	   1: begin
+	      if(sign_i)
+                divisor_reg <= divisor_reg[DATA_W-1]? -divisor_reg: divisor_reg;
+	   end
+
+	   DATA_W+2: begin  //apply sign to quotient
+              rq[DATA_W-1:0] <= (divident_sign^divisor_sign)? -rq[DATA_W-2 : 0]: rq[DATA_W-2 : 0];
+	   end
+	   
+	   DATA_W+3: begin  //apply sign to remainder
+	      done_o <= 1'b1;
+	      rq[2*DATA_W-1:DATA_W] <= divident_sign? -rq[2*DATA_W-1 -: DATA_W] : rq[2*DATA_W-1 -: DATA_W];
+	   end
+
+	   DATA_W+4: pc <= pc;  //finish
+	   
+	   default: begin //shift and subtract
+	      tmp = {1'b0, subtraend} - {1'b0, divisor_reg};
+              if(~tmp[DATA_W])
+                rq <= {tmp, rq[DATA_W-2 : 0], 1'b1};
+              else 
+                rq <= {rq[2*DATA_W-2 : 0], 1'b0};
+           end
+         endcase // case (pc)
+         
+      end else begin // if (en)
+         rq <= 1'b0;
+         done_o <= 1'b0;
+         pc <= 1'b0;
+      end
+   end // always @ *
+
+endmodule

--- a/hardware/modules/regfile/iob_regfile_sp/iob_regfile_sp_tb.v
+++ b/hardware/modules/regfile/iob_regfile_sp/iob_regfile_sp_tb.v
@@ -102,7 +102,7 @@ module iob_regfile_sp_tb;
       .DATA_W(`DATA_W)
    ) uut (
       .clk_i   (clk),
-      .rst_i   (rst),
+      .arst_i  (rst),
       .we_i    (en),
       .addr_i  (addr),
       .w_data_i(w_data),

--- a/scripts/verilog-lint.py
+++ b/scripts/verilog-lint.py
@@ -12,8 +12,8 @@ import subprocess
 import iob_colors
 
 linters = [
-  {"command": "verilator --lint-only -Wall", "include_flag": "-I"},
-#  {"command": "svlint", "include_flag": "-i"}
+    {"command": "verilator --lint-only -Wall", "include_flag": "-I"},
+    #  {"command": "svlint", "include_flag": "-i"}
 ]
 
 # Get list of files to lint from argv
@@ -25,47 +25,56 @@ for file in files_list:
     file_dir = os.path.dirname(file)
 
     if not file_dir in dir_file_list:
-      dir_file_list[file_dir] = []
+        dir_file_list[file_dir] = []
 
     dir_file_list[file_dir].append(file)
 
-#print(dir_file_list, file=sys.stderr) #DEBUG
+# print(dir_file_list, file=sys.stderr) #DEBUG
 
 files_to_lint = {}
 directories_to_lint = {}
 parent_dirs = []
 for child_dir in dir_file_list.keys():
-  #print(f"debug: {child_dir}", file=sys.stderr) #DEBUG
-  files_to_lint[child_dir] = []
-  directories_to_lint[child_dir] = []
+    # print(f"debug: {child_dir}", file=sys.stderr) #DEBUG
+    files_to_lint[child_dir] = []
+    directories_to_lint[child_dir] = []
 
-  # Find parents of this directory
-  for directory, file_list in dir_file_list.items():
-    dir_name = os.path.dirname(directory) if os.path.basename(directory) == "src" else directory
-    # If this directory is a parent (or equal) to the child_dir, add files to the list
-    if os.path.commonprefix([dir_name, child_dir])==dir_name and directory != child_dir+"/src":
-      files_to_lint[child_dir] += file_list
-      directories_to_lint[child_dir].append(directory)
-      #print(f"   {directory}", file=sys.stderr) #DEBUG
+    # Find parents of this directory
+    for directory, file_list in dir_file_list.items():
+        dir_name = (
+            os.path.dirname(directory)
+            if os.path.basename(directory) == "src"
+            else directory
+        )
+        # If this directory is a parent (or equal) to the child_dir, add files to the list
+        if (
+            os.path.commonprefix([dir_name, child_dir]) == dir_name
+            and directory != child_dir + "/src"
+        ):
+            files_to_lint[child_dir] += file_list
+            directories_to_lint[child_dir].append(directory)
+            # print(f"   {directory}", file=sys.stderr) #DEBUG
 
-      # Add this directory to the list of parent directories if it is not the child
-      if directory not in parent_dirs and directory != child_dir:
-        #print(f'PARENT: {directory}', file=sys.stderr)
-        parent_dirs.append(directory)
+            # Add this directory to the list of parent directories if it is not the child
+            if directory not in parent_dirs and directory != child_dir:
+                # print(f'PARENT: {directory}', file=sys.stderr)
+                parent_dirs.append(directory)
 
 # Remove parent directories from dictionary
 for directory in parent_dirs:
-  del files_to_lint[directory]
-  del directories_to_lint[directory]
+    del files_to_lint[directory]
+    del directories_to_lint[directory]
 
 for linter in linters:
-  # Lint files for each directory combination
-  for directory, files in files_to_lint.items():
-    print(f'\n{iob_colors.INFO}Linting from base directory "{directory}"{iob_colors.ENDC}')
-    linter_cmd = f"{linter['command']} {linter['include_flag']}{(' '+linter['include_flag']).join(directories_to_lint[directory])} {' '.join(files)}"
-    print(linter_cmd)
-    result = subprocess.run(linter_cmd, shell=True)
-    exit(result.returncode)
+    # Lint files for each directory combination
+    for directory, files in files_to_lint.items():
+        print(
+            f'\n{iob_colors.INFO}Linting from base directory "{directory}"{iob_colors.ENDC}'
+        )
+        linter_cmd = f"{linter['command']} {linter['include_flag']}{(' '+linter['include_flag']).join(directories_to_lint[directory])} {' '.join(files)}"
+        print(linter_cmd)
+        result = subprocess.run(linter_cmd, shell=True)
+        exit(result.returncode)
 
 # DEBUG: Print child directories and files to lint
 #    print("Base dir: "+directory, file=sys.stderr)

--- a/setup.mk
+++ b/setup.mk
@@ -41,11 +41,15 @@ BUILD_TSRC_DIR = $(BUILD_DOC_DIR)/tsrc
 
 python-format:
 	$(LIB_DIR)/scripts/sw_format.py black . 
+ifneq ($(wildcard $(BUILD_DIR)),)
 	$(LIB_DIR)/scripts/sw_format.py black $(BUILD_DIR) 
+endif
 
 c-format:
 	$(LIB_DIR)/scripts/sw_format.py clang .
+ifneq ($(wildcard $(BUILD_DIR)),)
 	$(LIB_DIR)/scripts/sw_format.py clang $(BUILD_DIR)
+endif
 
 IOB_LIB_PATH=$(LIB_DIR)/scripts
 export IOB_LIB_PATH


### PR DESCRIPTION
- update regfile_sp instantiation in testbench
- fixes LIB CI flow 
- format `verilog-lint.py` script
- improve format targets: only run formater on BUILD_DIR if directory
  exists. This allows to run `make python-format` target as standalone
  even without running `make setup` or creating BUILD_DIR
- add divisor modules to lib
- subshift, subshift_frac, subshift_signed and pipelined versions
- modules and testbenches taken from IObundle/iob-div repository