### PR TITLE
Update simulation `test` target; Update `mk_configuration.py`.

### DIFF
--- a/hardware/simulation/Makefile
+++ b/hardware/simulation/Makefile
@@ -97,23 +97,7 @@ fix-vcd:
 	@tail -n 1 $(VCD_FILE) | wc -c | xargs -I {} truncate $(VCD_FILE) -s -{}
 	@echo "" >> $(VCD_FILE)
 
-# ssh's remote server to run all tests; otherwise, it takes a lot of time to ssh for each individual test
-test: very-clean clean-test-log
-ifneq ($(SIM_SERVER),)
-	ssh $(SIM_SSH_FLAGS) $(SIM_USER)@$(SIM_SERVER) "if [ ! -d $(REMOTE_BUILD_DIR) ]; then mkdir -p $(REMOTE_BUILD_DIR); fi"
-	rsync $(SIM_SYNC_FLAGS) -avz --force --delete ../.. $(SIM_USER)@$(SIM_SERVER):$(REMOTE_BUILD_DIR)
-	ssh -t $(SIM_SSH_FLAGS) $(SIM_USER)@$(SIM_SERVER) 'make -C $(REMOTE_SIM_DIR) run-tests SIMULATOR=$(SIMULATOR) $(UFLAGS)'
-	sleep 1 && sync && scp $(SIM_SCP_FLAGS) $(SIM_USER)@$(SIM_SERVER):$(REMOTE_SIM_DIR)/*.log .
-ifeq ($(COV),1)
-	sleep 1 && sync && scp -r $(SIM_SCP_FLAGS) $(SIM_USER)@$(SIM_SERVER):$(REMOTE_SIM_DIR)/cov_work .
-	sleep 1 && sync && scp $(SIM_SCP_FLAGS) $(SIM_USER)@$(SIM_SERVER):$(REMOTE_SIM_DIR)/coverage_report_summary.rpt .
-	sleep 1 && sync && scp $(SIM_SCP_FLAGS) $(SIM_USER)@$(SIM_SERVER):$(REMOTE_SIM_DIR)/coverage_report_detail.rpt .
-endif
-else
-	make run-tests
-endif
-
-run-tests: $(TEST_LIST)
+test: very-clean clean-test-log $(TEST_LIST)
 	test "$$(cat test.log)" = "Test passed!"
 
 gen-clean:

--- a/scripts/mk_configuration.py
+++ b/scripts/mk_configuration.py
@@ -104,8 +104,13 @@ def append_flows_config_build_mk(flows_list, flows_filter, build_dir):
 
     if not flows2append:
         return
+
+    append_str_config_build_mk(f"FLOWS+={flows2append}\n\n", build_dir)
+
+# Append a string to the config_build.mk
+def append_str_config_build_mk(str_2_append, build_dir):
     file = open(f"{build_dir}/config_build.mk", "a")
-    file.write(f"FLOWS+={flows2append}\n\n")
+    file.write(str_2_append)
     file.close()
 
 


### PR DESCRIPTION
- Add function in `mk_configuration.py` to insert generic strings into `config_build.mk`.
  - This function is useful to set build time configuration, such as changing the default simulator by inserting the string `SIMULATOR:=verilator` into the `config_build.mk`.
- Update simulation `test` target to be similar to the FPGA. 
  - This change makes the simulation `test` target run targets from the `$(TEST_LIST)` in a similar way to the FPGA `test` target.
   - In relation to the problem raised by this comment:
     ```
     # ssh's remote server to run all tests; otherwise, it takes a lot of time to ssh for each individual test
     ```
     This problem should be solved by the targets inside the `sim_build.mk` file.
     If there are too many ssh connections, then we should update the target inside the `sim_build.mk` file to only make one connection and then run the various commands/tests inside that single connection.