### PR TITLE
fix(div): fix div module

### DIFF
--- a/hardware/modules/div/iob_div_subshift/iob_div_subshift.v
+++ b/hardware/modules/div/iob_div_subshift/iob_div_subshift.v
@@ -68,7 +68,7 @@ module iob_div_subshift
    always @* begin
       pc_nxt = pc+1'b1;
       dqr_nxt = dqr_reg;
-      divisor_nxt = divisor_i;
+      divisor_nxt = divisor_reg;
       done_o = 1'b1;
       
       case (pc)


### PR DESCRIPTION
- store divisor value on `start_i` instead on using direct input port by default
- this fixes problems when `divisor_i` changes in the middle of division operation
- replicates `dividend` logic