### PR TITLE
feat(s2f_sync): update s2f_sync module

### DIFF
--- a/hardware/modules/iob_s2f_sync/iob_s2f_sync.py
+++ b/hardware/modules/iob_s2f_sync/iob_s2f_sync.py
@@ -4,8 +4,7 @@ import shutil
 from iob_module import iob_module
 from setup import setup
 
-from iob_counter import iob_counter
-from iob_reg_re import iob_reg_re
+from iob_sync import iob_sync
 
 
 class iob_s2f_sync(iob_module):
@@ -20,8 +19,7 @@ class iob_s2f_sync(iob_module):
 
         # Setup dependencies
 
-        iob_counter.setup()
-        iob_reg_re.setup()
+        iob_sync.setup()
 
         if cls.is_top_module:
             # Setup flows of this core using LIB setup function

--- a/hardware/modules/iob_s2f_sync/iob_s2f_sync.v
+++ b/hardware/modules/iob_s2f_sync/iob_s2f_sync.v
@@ -17,39 +17,19 @@ module iob_s2f_sync #(
    output [DATA_W-1:0] data_o
 );
 
-   wire [DATA_W-1:0] data1;
-   wire [DATA_W-1:0] data2;
-   wire [DATA_W-1:0] sync;
+   wire [DATA_W-1:0] ld_reg0 = ld_i ? ld_val_i : data_i;
+   
+   wire [DATA_W-1:0] data_rst0 = rst_i ? RST_VAL : ld_reg0;
 
-   assign data1 = ld_i ? ld_val_i : data_i;
-   assign data2 = ld_i ? ld_val_i : sync;
-
-   iob_reg_r #(
-       .DATA_W(DATA_W), 
-       .RST_VAL(RST_VAL)
-   ) reg0 (
-      .clk_i (clk_i),
-      .arst_i(arst_i),
-      .cke_i (cke_i),
-
-      .rst_i(rst_i),
-
-      .data_i(data1),
-      .data_o(sync)
-   );
-
-   iob_reg_r #(
-       .DATA_W(DATA_W), 
-       .RST_VAL(RST_VAL)
-   ) reg1 (
-      .clk_i (clk_i),
-      .arst_i(arst_i),
-      .cke_i (cke_i),
-
-      .rst_i(rst_i),
-
-      .data_i(data2),
-      .data_o(data_o)
+   iob_sync #(
+       .DATA_W  (DATA_W),
+       .RST_VAL (RST_VAL),
+       .CLKEDGE ("posedge")
+   ) iob_sync_inst0 (
+       .clk_i   (clk_i),
+       .arst_i  (arst_i),
+       .signal_i(data_rst0),
+       .signal_o(data_o)
    );
 
 endmodule


### PR DESCRIPTION
- update s2f_sync module to use `iob_sync` instance
- this enables usage of constraints for vivado tools like:
```
set_property ASYNC_REG TRUE [get_cells -hier {*synchronizer*[*]}]
set_property ASYNC_REG TRUE [get_cells -hier {*signal_o*[*]}]
```
- previous implementation used regular `iob_reg`.