### PR TITLE
Fixing errors shown by iverilog

### DIFF
--- a/hardware/modules/iob_and/hardware/src/iob_and.v
+++ b/hardware/modules/iob_and/hardware/src/iob_and.v
@@ -3,7 +3,7 @@
 
 module iob_and
   #(
-    parameter W = 21
+    parameter W = 21,
     parameter N = 21
 ) (
    input [N*W-1:0] in_i,

--- a/hardware/modules/iob_aoi/hardware/src/iob_aoi.v
+++ b/hardware/modules/iob_aoi/hardware/src/iob_aoi.v
@@ -14,7 +14,7 @@ module iob_aoi
 	wire or_out;
 
 	iob_and #(
-		.W(1)
+		.W(1),
 		.N(2)
 	) iob_and_ab (
 		.in_i({a_i,b_i}),
@@ -22,7 +22,7 @@ module iob_aoi
 	);
 
 	iob_and #(
-		.W(1)
+		.W(1),
 		.N(2)
 	) iob_and_cd (
 		.in_i({c_i,d_i}),
@@ -30,7 +30,7 @@ module iob_aoi
 	);
 
 	iob_or #(
-		.W(1)
+		.W(1),
 		.N(2)
 	) iob_or_abcd (
 		.in_i({aab,cad}),

--- a/hardware/modules/iob_or/hardware/src/iob_or.v
+++ b/hardware/modules/iob_or/hardware/src/iob_or.v
@@ -3,7 +3,7 @@
 
 module iob_or
   #(
-    parameter W = 21
+    parameter W = 21,
     parameter N = 21
 ) (
    input [N*W-1:0] in_i,

--- a/hardware/modules/iob_xor/hardware/src/iob_xor.v
+++ b/hardware/modules/iob_xor/hardware/src/iob_xor.v
@@ -3,7 +3,7 @@
 
 module iob_xor
   #(
-    parameter W = 21
+    parameter W = 21,
     parameter N = 21
 ) (
    input [N*W-1:0] in_i,


### PR DESCRIPTION
While running the `test.sh` script manually for the iob_aoi module, I noticed these syntax errors.
I'm still getting warnings like this `../src/iob_and.v:18: warning: and_vec[1+:1] is selecting after vector.` in both `iob_and` and `iob_or` and I suspect `iob_xor` suffers form the same problem.
I'm currently working on those.
