### PR TITLE
setup.mk: Added a condition to warn the user when not within a nix-shell

### DIFF
--- a/setup.mk
+++ b/setup.mk
@@ -5,6 +5,10 @@
 
 SHELL=bash
 
+#Verify if we are in a nix-shell
+ifeq ($(NIX_STORE),)
+$(error Please run this command from a nix-shell)
+endif
 
 help:
 	@echo The following targets are available:


### PR DESCRIPTION
This was made to avoid confusion caused by having error due to not running `nix-shell`