### PR TITLE
Correct bugs and add iob_demux2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 scripts/__pycache__
 scripts/vhparser.pyc
+
+*.out

--- a/hardware/modules/iob_demux2/hardware/iob_demux2.v
+++ b/hardware/modules/iob_demux2/hardware/iob_demux2.v
@@ -1,0 +1,24 @@
+`timescale 1ns / 1ps
+
+// Demux that works like iob_mux (uses an output reg).
+module iob_demux2 #(
+   parameter DATA_W = 21,
+   parameter N      = 21
+) (
+   input      [($clog2(N)+($clog2(N)==0))-1:0] sel_i,
+   input      [                    DATA_W-1:0] data_i,
+   output reg [                (N*DATA_W)-1:0] data_o
+);
+
+   //Select the data to output
+   integer i;
+   always @* begin
+      data_o = {N*DATA_W{1'b0}};
+      for (i = 0; i < N; i = i + 1) begin : gen_demux
+         if (i == sel_i) begin
+            data_o[i*DATA_W+:DATA_W] = data_i;
+         end
+      end
+   end
+
+endmodule

--- a/hardware/modules/iob_demux2/iob_demux2.py
+++ b/hardware/modules/iob_demux2/iob_demux2.py
@@ -1,0 +1,10 @@
+import os
+
+from iob_module import iob_module
+
+
+class iob_demux2(iob_module):
+    name = "iob_demux2"
+    version = "V0.10"
+    flows = "sim"
+    setup_dir = os.path.dirname(__file__)

--- a/hardware/modules/iob_split/hardware/src/iob_split.v
+++ b/hardware/modules/iob_split/hardware/src/iob_split.v
@@ -53,20 +53,45 @@ module iob_split #(
    // Route master request to selected follower
    //
 
-   // Avalid goes to the selected follower
    iob_demux #(
       .DATA_W (1),
       .N      (N)
    ) demux_avalid (
-      .sel_i (f_sel_r),
+      .sel_i (f_sel_i),
       .data_i(m_avalid_i),
       .data_o(f_avalid_o)
    );
 
-   // These go to all followers (only the one with asserted avalid will use them)
+   // Leave this with iob_demux2. Errors happen(ed?) in the waves if iob_demux is used.
    assign f_addr_o  = m_addr_i;
+   iob_demux2 #(
    assign f_wdata_o = m_wdata_i;
+      .DATA_W (ADDR_W),
    assign f_wstrb_o = m_wstrb_i;
+      .N      (N)
+   ) demux_addr (
+      .sel_i (f_sel_i),
+      .data_i(m_addr_i),
+      .data_o(f_addr_o)
+   );
+
+   iob_demux #(
+      .DATA_W (DATA_W),
+      .N      (N)
+   ) demux_wdata (
+      .sel_i (f_sel_i),
+      .data_i(m_wdata_i),
+      .data_o(f_wdata_o)
+   );
+
+   iob_demux #(
+      .DATA_W (DATA_W/8),
+      .N      (N)
+   ) demux_wstrb (
+      .sel_i (f_sel_i),
+      .data_i(m_wstrb_i),
+      .data_o(f_wstrb_o)
+   );
 
    //
    // Route selected follower response to master

--- a/hardware/modules/iob_split/iob_split.py
+++ b/hardware/modules/iob_split/iob_split.py
@@ -5,6 +5,7 @@ from iob_module import iob_module
 from iob_reg_re import iob_reg_re
 from iob_mux import iob_mux
 from iob_demux import iob_demux
+from iob_demux2 import iob_demux2
 
 
 class iob_split(iob_module):
@@ -22,6 +23,7 @@ class iob_split(iob_module):
                 {"interface": "clk_rst_s_s_portmap"},
                 iob_reg_re,
                 iob_demux,
+                iob_demux2,
                 iob_mux,
             ]
         )

--- a/scripts/submodule_utils.py
+++ b/scripts/submodule_utils.py
@@ -23,7 +23,7 @@ reserved_signals = {
     "iob_addr_i": ".iob_addr_i(periphs_dbus_addr[(`/*<InstanceFullName>*/)*/*<InstanceName>*/_ADDR_W +: /*<InstanceName>*/_ADDR_W])",
     "iob_wdata_i": ".iob_wdata_i(periphs_dbus_wdata[(`/*<InstanceFullName>*/)*/*<InstanceName>*/_DATA_W +: /*<InstanceName>*/_DATA_W])",
     "iob_wstrb_i": ".iob_wstrb_i(periphs_dbus_wstrb[(`/*<InstanceFullName>*/)*/*<InstanceName>*/_DATA_W/8 +: /*<InstanceName>*/_DATA_W/8])",
-    "iob_rdata_o": ".iob_rdata_o(periphs_dbus_rdata[(`/*<InstanceFullName>*/)*1 +: /*<InstanceName>*/_DATA_W])",
+    "iob_rdata_o": ".iob_rdata_o(periphs_dbus_rdata[(`/*<InstanceFullName>*/)*/*<InstanceName>*/_DATA_W +: /*<InstanceName>*/_DATA_W])",
     "iob_rvalid_o": ".iob_rvalid_o(periphs_dbus_rvalid[(`/*<InstanceFullName>*/)*1 +: 1])",
     "iob_ready_o": ".iob_ready_o(periphs_dbus_ready[(`/*<InstanceFullName>*/)*1 +: 1])",
     "trap_o": ".trap_o(/*<InstanceFullName>*/_trap_o)",


### PR DESCRIPTION
Corrected a bug in submodule_utils.py and another one in iob_split.py. The latter happened because 3 signals were not being distributed to all the followers - only to the first one.

To correct that bug, demux2 was added, working the same way as iob_mux - by storing the signals into a register instead of just assigning wires.