### PR TITLE
fix(fpga): remove VHDR overwrite

### DIFF
--- a/hardware/fpga/Makefile
+++ b/hardware/fpga/Makefile
@@ -33,7 +33,7 @@ include $(FPGA_TOOL)/$(BOARD)/board.mk
 include $(FPGA_TOOL)/build.mk
 
 #include the module's headers and sources
-VHDR = $(wildcard ../src/*.vh) $(wildcard ./src/*.vh)
+VHDR += $(wildcard ../src/*.vh) $(wildcard ./src/*.vh)
 VSRC += $(wildcard ../src/*.v) $(wildcard ./src/*.v)
 
 ifneq ($(wildcard $(FPGA_TOOL)/$(BOARD)/$(NAME)_fpga_wrapper.v),)


### PR DESCRIPTION
- append to VHDR variable instead of overwriting in fpga/Makefile - previously VHDR variable was potentially ignoring values set in `fpga_build.mk`