### PR TITLE
feat(swreg): update swreg instantiation

### DIFF
--- a/scripts/mkregs.py
+++ b/scripts/mkregs.py
@@ -273,8 +273,8 @@ class mkregs:
                 if not auto:
                     f.write(f"  .{name}_ready_i({name}_ready),\n")
 
-        f.write(f"  .iob_ready_nxt_o(iob_ready_nxt_o),\n")
-        f.write(f"  .iob_rvalid_nxt_o(iob_rvalid_nxt_o),\n")
+        f.write(f"  .iob_ready_nxt_o(iob_ready_nxt),\n")
+        f.write(f"  .iob_rvalid_nxt_o(iob_rvalid_nxt),\n")
 
     def write_hwcode(self, table, out_dir, top):
         #
@@ -291,7 +291,7 @@ class mkregs:
         f_inst.write(f'  `include "{top}_inst_params.vs"\n')
         f_inst.write("\n) swreg_0 (\n")
         self.gen_portmap(table, f_inst)
-        f_inst.write('  `include "iob_s_s_portmap.vs"\n')
+        f_inst.write('  `include "iob_s_portmap.vs"\n')
         f_inst.write("  .clk_i(clk_i),\n")
         f_inst.write("  .cke_i(cke_i),\n")
         f_inst.write("  .arst_i(arst_i)\n")


### PR DESCRIPTION
- update swreg instantiation to use internal wires for iob interface
- regular cores should have AXIL, APB or other standard interface/ports
  and use a CSR_IF -> IOb converter
- removes _i and _o sufixes from iob native wires