### PR TITLE
feat(pulse_gen): register output, testbench

### DIFF
--- a/hardware/modules/iob_pulse_gen/hardware/simulation/src/iob_pulse_gen_tb.v
+++ b/hardware/modules/iob_pulse_gen/hardware/simulation/src/iob_pulse_gen_tb.v
@@ -2,8 +2,10 @@
 
 module iob_pulse_gen_tb;
 
-   localparam START    = 0;
+   localparam START    = 2;
    localparam DURATION = 10;
+
+   parameter clk_per = 10;  // clk period = 10 timeticks
 
    reg clk;
    reg rst;
@@ -23,21 +25,51 @@ module iob_pulse_gen_tb;
       .pulse_o (pulse_o)
       );
 
+   integer i;
+   integer duration;
+   integer start;
    initial begin
+`ifdef VCD
+    $dumpfile("uut.vcd");
+    $dumpvars();
+`endif
+
       clk     = 0;
       rst     = 1;
+      start_i = 0;
 
-      #10 rst = 0;
+      duration= 0;
+      start = 0;
 
-      #10 start_i = 1;
-      #10 start_i = 0;
+      #clk_per rst = 0;
 
-      #100 $finish;
+      #clk_per start_i = 1;
+      #clk_per start_i = 0;
+
+      @(posedge clk); 
+      // wait for pulse to enable
+      while(pulse_o == 0) begin
+        @(posedge clk);
+        start = start + 1;
+      end
+
+      while(pulse_o == 1) begin
+        duration = duration + 1;
+        @(posedge clk);
+      end
+
+      if((duration == DURATION) & (start == START)) begin
+          $display("%c[1;34m", 27);
+          $display("Test completed successfully.");
+          $display("%c[0m", 27);
+      end else begin
+          $display("Test failed: duration %d\texpected %d", duration, DURATION);
+          $display("Test failed: start %d\texpected %d", start, START);
+      end
+      #(10*clk_per) $finish;
    end // initial begin
 
-   always begin
-      #5 clk = ~clk;
-   end // always begin
+   always #(clk_per / 2) clk = ~clk;
 
 endmodule
 


### PR DESCRIPTION
- update iob_pulse_gen:
  - register output
  - compensate extra cycle for output register for cases when `START > 0`: 
    - when START > 1, output is enabled START cycles after `start_i == 1`. 
    - When `START = 0`, output is enabled 1 cycle after `start_i == 1`
- update testbench for pulse_gen, checks for duration and start