### PR TITLE
feat(python): netlist processing script

### DIFF
--- a/scripts/netlist_proc.py
+++ b/scripts/netlist_proc.py
@@ -1,5 +1,21 @@
 #!/usr/bin/env python3
 
+"""
+Usage:
+- From a shell:
+    ./netlist_proc.py input_netlist.v output_netlist.v iob_top_module
+
+- From another python script:
+    import netlist_proc
+
+    netlist_proc.process_netlist(
+        input="input_netlist.v",
+        output="output_netlist.v",
+        top_module="iob_top_module",
+        prefix="_prefix_",
+    )
+"""
+
 import argparse
 import re
 import sys
@@ -41,7 +57,9 @@ def process_netlist(input, output, top_module, prefix="_"):
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(description="IObundle Netlist Processing Script")
+    parser = argparse.ArgumentParser(
+        description="IObundle Netlist Processing Script. Adds prefixes to all module names (except top module) to avoid module name collisions with other verilog sources."
+    )
     parser.add_argument("input", help="Input netlist file.")
     parser.add_argument("output", help="Output netlist file.")
     parser.add_argument("-t", help="Netlist top level module.")

--- a/scripts/netlist_proc.py
+++ b/scripts/netlist_proc.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+import argparse
+import re
+import sys
+
+
+def process_netlist(input, output, top_module):
+    print(f"Processing {input} to {output}")
+
+    # search pattern: "module <name>"
+    pattern = r"module\s+(\w+)"
+
+    # Read input netlist
+    with open(input, "r") as file:
+        content = file.read()
+
+    netlist_modules = []
+    # Iterate through the lines and look for the pattern
+    for line in content.splitlines():
+        match = re.search(pattern, line)
+        if match:
+            module_name = match.group(1)
+            netlist_modules.append(module_name)
+
+    # Remove top module
+    netlist_modules = [line for line in netlist_modules if line != top_module]
+
+    # replace all instances of <module name> with _<module_name>
+    for module_name in netlist_modules:
+        print(f"Replacing {module_name} with _{module_name}", file=sys.stderr)
+        replacement_string = f"_{module_name}"
+        content = content.replace(module_name, replacement_string)
+
+    # write processed netlist
+    with open(output, "w") as f:
+        f.write(content)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="IObundle Netlist Processing Script")
+    parser.add_argument("input", help="Input netlist file.")
+    parser.add_argument("output", help="Output netlist file.")
+    parser.add_argument("-t", help="Netlist top level module.")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    print("Netlist Processing Script")
+    args = parse_args()
+    print(args)
+    process_netlist(args.input, args.output, args.t)
+    pass

--- a/scripts/netlist_proc.py
+++ b/scripts/netlist_proc.py
@@ -5,8 +5,12 @@ import re
 import sys
 
 
-def process_netlist(input, output, top_module):
-    print(f"Processing {input} to {output}")
+def process_netlist(input, output, top_module, prefix="_"):
+    print("Netlist processing:")
+    print(f"\t\tInput: {input}")
+    print(f"\t\tOutput: {output}")
+    print(f"\t\tTop module: {top_module}")
+    print(f"\t\tPrefix: {prefix}")
 
     # search pattern: "module <name>"
     pattern = r"module\s+(\w+)"
@@ -26,10 +30,9 @@ def process_netlist(input, output, top_module):
     # Remove top module
     netlist_modules = [line for line in netlist_modules if line != top_module]
 
-    # replace all instances of <module name> with _<module_name>
+    # replace all instances of <module name> with {prefix}<module_name>
     for module_name in netlist_modules:
-        print(f"Replacing {module_name} with _{module_name}", file=sys.stderr)
-        replacement_string = f"_{module_name}"
+        replacement_string = f"{prefix}{module_name}"
         content = content.replace(module_name, replacement_string)
 
     # write processed netlist
@@ -42,12 +45,10 @@ def parse_args():
     parser.add_argument("input", help="Input netlist file.")
     parser.add_argument("output", help="Output netlist file.")
     parser.add_argument("-t", help="Netlist top level module.")
+    parser.add_argument("-p", default="_", help="Prefix to add to module names.")
     return parser.parse_args()
 
 
 if __name__ == "__main__":
-    print("Netlist Processing Script")
     args = parse_args()
-    print(args)
-    process_netlist(args.input, args.output, args.t)
-    pass
+    process_netlist(args.input, args.output, args.t, args.p)


### PR DESCRIPTION
- add python script to rename modules in netlist from <module name> to  <prefix><module name>
    - this avoids module re-definitions when a module is used by TESTER system and core netlist
    - add optional argument for custom prefix. `_` by default. This enables usage of different prefixes for each netlist to avoid colisions between netlists