### PR TITLE
fix(quartus): improve quartus report names

### DIFF
--- a/hardware/fpga/quartus/build.tcl
+++ b/hardware/fpga/quartus/build.tcl
@@ -166,6 +166,15 @@ if {$IS_FPGA != "1"} {
 project_close
 
 #rename report files
+set report_list [glob -directory "reports" *]
+# add NAME to all reports missing NAME prefix
+foreach report $report_list {
+    if {[string match "*${NAME}*" $report] == 0} {
+        set new_name "${NAME}.[file tail $report]"
+        file rename $report reports/$new_name
+    }
+}
+
 file rename reports/$NAME.fit.summary reports/$NAME\_$PART.fit.summary
 file rename reports/$NAME.sta.summary reports/$NAME\_$PART.sta.summary
 

--- a/hardware/fpga/quartus/build.tcl
+++ b/hardware/fpga/quartus/build.tcl
@@ -134,7 +134,14 @@ if {[catch {execute_module -tool sta -args "--report_script=quartus/timing.tcl"}
     puts "\nINFO: STA was successful.\n"
 }
 
-
+#rerun quartus sta to generate reports
+if [catch {qexec "[file join $::quartus(binpath) quartus_sta] -t quartus/timing.tcl $NAME"} result] {
+    puts "\nResult: $result\n"
+    puts "ERROR: STA failed. See report files.\n"
+    qexit -error
+} else {
+    puts "\nINFO: STA was successful.\n"
+}
     
 if {$IS_FPGA != "1"} {
 
@@ -166,16 +173,5 @@ if {$IS_FPGA != "1"} {
 project_close
 
 #rename report files
-set report_list [glob -directory "reports" *]
-# add NAME to all reports missing NAME prefix
-foreach report $report_list {
-    if {[string match "*${NAME}*" $report] == 0} {
-        set new_name "${NAME}.[file tail $report]"
-        file rename $report reports/$new_name
-    }
-}
-
 file rename reports/$NAME.fit.summary reports/$NAME\_$PART.fit.summary
 file rename reports/$NAME.sta.summary reports/$NAME\_$PART.sta.summary
-
-

--- a/hardware/fpga/quartus/timing.tcl
+++ b/hardware/fpga/quartus/timing.tcl
@@ -1,7 +1,14 @@
-report_path -nworst 5 -multi_corner -file reports/sta.paths
-report_path -min_path -file reports/sta.min_path
-report_max_skew -file reports/sta.skew
-report_metastability -file reports/sta.metastability
+set NAME [lindex $argv 0]
+
+project_open -force $NAME -revision $NAME
+create_timing_netlist
+read_sdc
+update_timing_netlist
+
+report_path -nworst 5 -multi_corner -file reports/$NAME.sta.paths
+report_path -min_path -file reports/$NAME.sta.min_path
+report_max_skew -file reports/$NAME.sta.skew
+report_metastability -file reports/$NAME.sta.metastability
 
 set setup_domain_list [get_clock_domain_info -setup]
 
@@ -9,6 +16,8 @@ set setup_domain_list [get_clock_domain_info -setup]
 foreach domain $setup_domain_list {
     # replace space with '_'
     set domain_name [string map {" " "_" } $domain]
-    report_timing -nworst 5 -setup -to_clock [lindex $domain 0] -file reports/$domain_name.setup.sta.timing
-    report_timing -nworst 5 -hold -to_clock [lindex $domain 0] -file reports/$domain_name.hold.sta.timing
+    report_timing -nworst 5 -setup -to_clock [lindex $domain 0] -file reports/$NAME.$domain_name.setup.sta.timing
+    report_timing -nworst 5 -hold -to_clock [lindex $domain 0] -file reports/$NAME.$domain_name.hold.sta.timing
 }
+
+catch {delete_timing_netlist}

--- a/hardware/fpga/quartus/timing.tcl
+++ b/hardware/fpga/quartus/timing.tcl
@@ -1,14 +1,14 @@
-set NAME [lindex $argv 0]
-
-report_path -nworst 5 -multi_corner -file reports/$NAME.sta.paths
-report_path -min_path -file reports/$NAME.sta.min_path
-report_max_skew -file reports/$NAME.sta.skew
-report_metastability -file reports/$NAME.sta.metastability
+report_path -nworst 5 -multi_corner -file reports/sta.paths
+report_path -min_path -file reports/sta.min_path
+report_max_skew -file reports/sta.skew
+report_metastability -file reports/sta.metastability
 
 set setup_domain_list [get_clock_domain_info -setup]
 
 # Report the Worst Case Setups slacks per clock
 foreach domain $setup_domain_list {
-    report_timing -nworst 5 -setup -to_clock [lindex $domain 0] -file reports/$NAME.$domain.setup.sta.timing
-    report_timing -nworst 5 -hold -to_clock [lindex $domain 0] -file reports/$NAME.$domain.hold.sta.timing
+    # replace space with '_'
+    set domain_name [string map {" " "_" } $domain]
+    report_timing -nworst 5 -setup -to_clock [lindex $domain 0] -file reports/$domain_name.setup.sta.timing
+    report_timing -nworst 5 -hold -to_clock [lindex $domain 0] -file reports/$domain_name.hold.sta.timing
 }


### PR DESCRIPTION
- timing.tcl: do not use NAME variable (was adding -report_script prefix to all reports)
- build.tcl: add core name prefix to all reports